### PR TITLE
Fix drag and drop registration

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -239,6 +239,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
         self.previousHorizontalSelectionDirection = MBHorizontalEdgeLeft;
 		
 		self.columnRects = [NSMutableDictionary dictionary];
+        [self registerForDraggedTypes:@[MBTableGridColumnDataType, MBTableGridRowDataType]];
 	}
 	return self;
 }
@@ -446,15 +447,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
     return offset;
 }
 
-- (void)registerForDraggedTypes:(NSArray *)pboardTypes {
-	// Add the column and row types to the array
-	NSMutableArray *types = [NSMutableArray arrayWithArray:pboardTypes];
-
-	if (!pboardTypes) {
-		types = [NSMutableArray array];
-	}
-	[types addObjectsFromArray:@[MBTableGridColumnDataType, MBTableGridRowDataType]];
-
+- (void)registerForDraggedTypes:(NSArray *)types {
 	[super registerForDraggedTypes:types];
 
 	// Register the content view for everything


### PR DESCRIPTION
Previously the table grid would fail to register its own drag types unless the client application explicitly called `registerDraggedTypes:`. This would allow rows and columns to be dragged, but not dropped on the grid. Now we explicitly register the grid's internal types in `initWithFrame:`.