### PR TITLE
columnAtPoint: fix

### DIFF
--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -819,7 +819,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	NSInteger column = 0;
 	while(column < self.tableGrid.numberOfColumns) {
 		NSRect columnFrame = [self rectOfColumn:column];
-		if(aPoint.x > columnFrame.origin.x && aPoint.x < (columnFrame.origin.x + columnFrame.size.width)) {
+		if(aPoint.x >= columnFrame.origin.x && aPoint.x < (columnFrame.origin.x + columnFrame.size.width)) {
 			return column;
 		}
 		column++;


### PR DESCRIPTION
Points lying exactly on the column boundary (at the frame origin) would not match any column.