### PR TITLE
Column resize fix

### DIFF
--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -338,7 +338,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
         // Resize column and resize views
 		
         CGFloat offset = [self.tableGrid resizeColumnWithIndex:draggingColumnIndex withDistance:dragDistance location:loc];
-       // lastMouseDraggingLocation.x += offset;
+        lastMouseDraggingLocation.x += offset;
         
         if (offset != 0.0) {
             [[NSCursor resizeRightCursor] set];


### PR DESCRIPTION
Currently if the mouse is moved far to the left of the minimum column width, moving the mouse rightward will enlarge the column header, even though the cursor is still to the left of the drag handle.

Restoring this line of code produces the expected behavior of enlarging the column header only when the cursor has the same X coordinate as the drag handle.