### PR TITLE
Fix deselection when clicking outside the MBTableGrid

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -386,7 +386,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		parent = parent.superview;
 	}
 
-	if(!isBeneathContentView) {
+	if (v != nil && !isBeneathContentView) {
 		NSEvent* event = self.window.currentEvent;
 		if(event != nil && event.type == NSLeftMouseDown) {
 			// Clear selection


### PR DESCRIPTION
Currently, clicks outside the table grid result in a deselection because `hitTest:` is still called on the table grid. So test for a successful hit test (i.e. hitting this view or a subview) before performing the
deselection logic.