### PR TITLE
Modernize Objective-C code

### DIFF
--- a/MBFooterTextCell.m
+++ b/MBFooterTextCell.m
@@ -19,8 +19,8 @@
 
 - (NSAttributedString *)attributedTitle
 {
-    NSColor *color = [NSColor controlTextColor];
-    NSDictionary *attributes = @{NSFontAttributeName : self.attributedTitleFont, NSForegroundColorAttributeName : color};
+    NSColor *color = NSColor.controlTextColor;
+    NSDictionary<NSAttributedStringKey, id> *attributes = @{NSFontAttributeName : self.attributedTitleFont, NSForegroundColorAttributeName : color};
     
     return [[NSAttributedString alloc] initWithString:self.title attributes:attributes];
 }

--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -140,8 +140,8 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
 	/* Sticky Edges (for Shift+Arrow expansions) */
 	MBHorizontalEdge stickyColumnEdge;
 	MBVerticalEdge stickyRowEdge;
-	NSMutableArray *columnIndexNames;
-	NSMutableDictionary* _columnWidths;
+	NSMutableArray<NSString *> *columnIndexNames;
+	NSMutableDictionary<NSNumber *, NSNumber *>* _columnWidths;
 	
 }
 
@@ -215,7 +215,7 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
  *
  */
 
-@property (nonatomic, strong) NSMutableDictionary *columnRects;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSValue *> *columnRects;
 
 
 - (void) resizeColumnWithIndex:(NSUInteger)columnIndex width:(float)w;
@@ -301,7 +301,7 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
  * @return		A NSArray for use with the sort indicator.
  */
 
-@property (nonatomic, strong) NSArray *sortButtons;
+@property (nonatomic, strong) NSArray<NSButton *> *sortButtons;
 
 /**
  * @brief		Sets the indicator image for the specified column.

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -85,15 +85,15 @@ NSString *MBTableGridRowDataType = @"mbtablegrid.pasteboard.row";
 - (NSUInteger)indexForExpansionInHorizontalDirection:(MBHorizontalEdge)direction
 {
     return (direction == MBHorizontalEdgeLeft)
-        ? [self firstIndex]
-        : [self lastIndex];
+        ? self.firstIndex
+        : self.lastIndex;
 }
 
 - (NSUInteger)indexForExpansionInVerticalDirection:(MBVerticalEdge)direction
 {
     return (direction == MBVerticalEdgeTop)
-        ? [self firstIndex]
-        : [self lastIndex];
+        ? self.firstIndex
+        : self.lastIndex;
 }
 @end
 
@@ -136,8 +136,8 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		_columnWidths = [NSMutableDictionary dictionary];
 
 		// Post frame changed notifications
-		[self setPostsFrameChangedNotifications:YES];
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(viewFrameDidChange:) name:NSViewFrameDidChangeNotification object:self];
+		self.postsFrameChangedNotifications = YES;
+		[NSNotificationCenter.defaultCenter addObserver:self selector:@selector(viewFrameDidChange:) name:NSViewFrameDidChangeNotification object:self];
 
 		// Set the default cell
 		MBTableGridCell *defaultCell = [[MBTableGridCell alloc] initTextCell:@""];
@@ -243,22 +243,22 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
                                                                          constant:MBTableGridRowHeaderWidth]];
 
 		// We want to synchronize the scroll views
-        [[NSNotificationCenter defaultCenter] addObserver:self
+        [NSNotificationCenter.defaultCenter addObserver:self
 												 selector:@selector(columnHeaderViewDidScroll:)
 													 name:NSScrollViewDidLiveScrollNotification
 												   object:columnHeaderScrollView];
         
-        [[NSNotificationCenter defaultCenter] addObserver:self
+        [NSNotificationCenter.defaultCenter addObserver:self
 												 selector:@selector(rowHeaderViewDidScroll:)
 													 name:NSScrollViewDidLiveScrollNotification
 												   object:rowHeaderScrollView];
         
-        [[NSNotificationCenter defaultCenter] addObserver:self
+        [NSNotificationCenter.defaultCenter addObserver:self
 												 selector:@selector(columnFooterViewDidScroll:)
 													 name:NSScrollViewDidLiveScrollNotification
 												   object:columnFooterScrollView];
         
-        [[NSNotificationCenter defaultCenter] addObserver:self
+        [NSNotificationCenter.defaultCenter addObserver:self
 												 selector:@selector(contentViewDidScroll:)
 													 name:NSScrollViewDidLiveScrollNotification
 												   object:contentScrollView];
@@ -300,7 +300,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)dealloc {
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
 - (BOOL)isFlipped {
@@ -376,7 +376,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)drawRect:(NSRect)aRect {
-	[[NSColor windowBackgroundColor] set];
+	[NSColor.windowBackgroundColor set];
 	NSRectFill(aRect);
 }
 
@@ -422,7 +422,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 	if (v != nil && !isBeneathContentView) {
 		NSEvent* event = self.window.currentEvent;
-		if(event != nil && event.type == NSLeftMouseDown) {
+        if(event != nil && event.type == NSEventTypeLeftMouseDown) {
 			// Clear selection
 			NSIndexSet* empty = [NSIndexSet indexSet];
 			[self setSelectedRowIndexes:empty notify:YES];
@@ -448,7 +448,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
     
     CGFloat minColumnWidth = MBTableHeaderMinimumColumnWidth;
     
-    if (columnHeaderView.indicatorImage && [columnHeaderView.indicatorImageColumns containsObject:[NSNumber numberWithInteger:columnIndex]]) {
+    if (columnHeaderView.indicatorImage && [columnHeaderView.indicatorImageColumns containsObject:@(columnIndex)]) {
         minColumnWidth += columnHeaderView.indicatorImage.size.width + 2.0f;
     }
     
@@ -480,7 +480,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
     return offset;
 }
 
-- (void)registerForDraggedTypes:(NSArray *)types {
+- (void)registerForDraggedTypes:(NSArray<NSPasteboardType> *)types {
 	[super registerForDraggedTypes:types];
 
 	// Register the content view for everything
@@ -491,11 +491,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (void)mouseDown:(NSEvent *)theEvent {
 	// End editing (if necessary)
-	[[self cell] endEditing:[[self window] fieldEditor:NO forObject:contentView]];
+	[self.cell endEditing:[self.window fieldEditor:NO forObject:contentView]];
 
 	// If we're not the first responder, we need to be
-	if ([[self window] firstResponder] != self) {
-		[[self window] makeFirstResponder:self];
+	if (self.window.firstResponder != self) {
+		[self.window makeFirstResponder:self];
 	}
 }
 
@@ -555,7 +555,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)insertNewline:(id)sender {
-	if ([[NSApp currentEvent] modifierFlags] & NSShiftKeyMask) {
+    if (NSApp.currentEvent.modifierFlags & NSEventModifierFlagShift) {
 		// Pressing Shift+Return moves to the previous row
 		shouldOverrideModifiers = YES;
 		[self moveUp:sender];
@@ -571,15 +571,15 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)moveUp:(id)sender {
-	NSUInteger column = [self.selectedColumnIndexes firstIndex];
-	NSUInteger row = [self.selectedRowIndexes firstIndex];
+	NSUInteger column = self.selectedColumnIndexes.firstIndex;
+	NSUInteger row = self.selectedRowIndexes.firstIndex;
 
 	// Accomodate for the sticky edges
 	if (stickyColumnEdge == MBHorizontalEdgeRight) {
-		column = [self.selectedColumnIndexes lastIndex];
+		column = self.selectedColumnIndexes.lastIndex;
 	}
 	if (stickyRowEdge == MBVerticalEdgeBottom) {
-		row = [self.selectedRowIndexes lastIndex];
+		row = self.selectedRowIndexes.lastIndex;
 	}
 
     if (row <= 0) { return; }
@@ -601,11 +601,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		return;
 	}
 
-	NSUInteger firstRow = [self.selectedRowIndexes firstIndex];
-	NSUInteger lastRow = [self.selectedRowIndexes lastIndex];
+	NSUInteger firstRow = self.selectedRowIndexes.firstIndex;
+	NSUInteger lastRow = self.selectedRowIndexes.lastIndex;
 
 	// If there is only one row selected, change the sticky edge to the bottom
-	if ([self.selectedRowIndexes count] == 1) {
+	if (self.selectedRowIndexes.count == 1) {
 		stickyRowEdge = MBVerticalEdgeBottom;
 	}
 
@@ -626,15 +626,15 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)moveDown:(id)sender {
-	NSUInteger column = [self.selectedColumnIndexes firstIndex];
-	NSUInteger row = [self.selectedRowIndexes firstIndex];
+	NSUInteger column = self.selectedColumnIndexes.firstIndex;
+	NSUInteger row = self.selectedRowIndexes.firstIndex;
 
 	// Accomodate for the sticky edges
 	if (stickyColumnEdge == MBHorizontalEdgeRight) {
-		column = [self.selectedColumnIndexes lastIndex];
+		column = self.selectedColumnIndexes.lastIndex;
 	}
 	if (stickyRowEdge == MBVerticalEdgeBottom) {
-		row = [self.selectedRowIndexes lastIndex];
+		row = self.selectedRowIndexes.lastIndex;
 	}
 
     if (row >= (_numberOfRows - 1)) { return; }
@@ -652,11 +652,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		return;
 	}
 
-	NSUInteger firstRow = [self.selectedRowIndexes firstIndex];
-	NSUInteger lastRow = [self.selectedRowIndexes lastIndex];
+	NSUInteger firstRow = self.selectedRowIndexes.firstIndex;
+	NSUInteger lastRow = self.selectedRowIndexes.lastIndex;
 
 	// If there is only one row selected, change the sticky edge to the top
-	if ([self.selectedRowIndexes count] == 1) {
+	if (self.selectedRowIndexes.count == 1) {
 		stickyRowEdge = MBVerticalEdgeTop;
 	}
 
@@ -678,15 +678,15 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)moveLeft:(id)sender {
-	NSUInteger column = [self.selectedColumnIndexes firstIndex];
-	NSUInteger row = [self.selectedRowIndexes firstIndex];
+	NSUInteger column = self.selectedColumnIndexes.firstIndex;
+	NSUInteger row = self.selectedRowIndexes.firstIndex;
 
 	// Accomodate for the sticky edges
 	if (stickyColumnEdge == MBHorizontalEdgeRight) {
-		column = [self.selectedColumnIndexes lastIndex];
+		column = self.selectedColumnIndexes.lastIndex;
 	}
 	if (stickyRowEdge == MBVerticalEdgeBottom) {
-		row = [self.selectedRowIndexes lastIndex];
+		row = self.selectedRowIndexes.lastIndex;
 	}
 
 	if (column == 0) {
@@ -709,11 +709,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		return;
 	}
 
-	NSUInteger firstColumn = [self.selectedColumnIndexes firstIndex];
-	NSUInteger lastColumn = [self.selectedColumnIndexes lastIndex];
+	NSUInteger firstColumn = self.selectedColumnIndexes.firstIndex;
+	NSUInteger lastColumn = self.selectedColumnIndexes.lastIndex;
 
 	// If there is only one column selected, change the sticky edge to the right
-	if ([self.selectedColumnIndexes count] == 1) {
+	if (self.selectedColumnIndexes.count == 1) {
 		stickyColumnEdge = MBHorizontalEdgeRight;
 	}
 
@@ -734,15 +734,15 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)moveRight:(id)sender {
-	NSUInteger column = [self.selectedColumnIndexes firstIndex];
-	NSUInteger row = [self.selectedRowIndexes firstIndex];
+	NSUInteger column = self.selectedColumnIndexes.firstIndex;
+	NSUInteger row = self.selectedRowIndexes.firstIndex;
 
 	// Accomodate for the sticky edges
 	if (stickyColumnEdge == MBHorizontalEdgeRight) {
-		column = [self.selectedColumnIndexes lastIndex];
+		column = self.selectedColumnIndexes.lastIndex;
 	}
 	if (stickyRowEdge == MBVerticalEdgeBottom) {
-		row = [self.selectedRowIndexes lastIndex];
+		row = self.selectedRowIndexes.lastIndex;
 	}
 
 	// If we're already at the last column, move down and to the leftmost column
@@ -767,11 +767,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
         return;
     }
 
-    NSUInteger firstColumn = [self.selectedColumnIndexes firstIndex];
-    NSUInteger lastColumn = [self.selectedColumnIndexes lastIndex];
+    NSUInteger firstColumn = self.selectedColumnIndexes.firstIndex;
+    NSUInteger lastColumn = self.selectedColumnIndexes.lastIndex;
 
     // If there is only one column selected, change the sticky edge to the right
-    if ([self.selectedColumnIndexes count] == 1) {
+    if (self.selectedColumnIndexes.count == 1) {
         stickyColumnEdge = MBHorizontalEdgeLeft;
     }
 
@@ -833,7 +833,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
     NSUInteger column = [self.selectedColumnIndexes indexForExpansionInHorizontalDirection:horizontal];
     NSUInteger row = [self.selectedRowIndexes indexForExpansionInVerticalDirection:vertical];
 
-    if (column > [self numberOfColumns]) { return; }
+    if (column > self.numberOfColumns) { return; }
 
     NSRect visibleRect = self.contentView.visibleRect;
     NSRect cellRect = [self frameOfCellAtColumn:column row:row];
@@ -866,7 +866,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 - (void)scrollToArea:(NSRect)area animate:(BOOL)shouldAnimate {
 	if (shouldAnimate) {
 		[NSAnimationContext runAnimationGroup: ^(NSAnimationContext *context) {
-		    [context setAllowsImplicitAnimation:YES];
+		    context.allowsImplicitAnimation = YES;
 		    [self.contentView scrollRectToVisible:area];
 		} completionHandler: ^{ }];
 	}
@@ -930,10 +930,10 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (void)deleteBackward:(id)sender {
 	// Clear the contents of every selected cell
-	NSUInteger column = [self.selectedColumnIndexes firstIndex];
-	while (column <= [self.selectedColumnIndexes lastIndex]) {
-		NSUInteger row = [self.selectedRowIndexes firstIndex];
-		while (row <= [self.selectedRowIndexes lastIndex]) {
+	NSUInteger column = self.selectedColumnIndexes.firstIndex;
+	while (column <= self.selectedColumnIndexes.lastIndex) {
+		NSUInteger row = self.selectedRowIndexes.firstIndex;
+		while (row <= self.selectedRowIndexes.lastIndex) {
 			[self _setObjectValue:nil forColumn:column row:row];
 			row++;
 		}
@@ -943,22 +943,22 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)insertText:(id)aString {
-	NSUInteger column = [self.selectedColumnIndexes firstIndex];
-	NSUInteger row = [self.selectedRowIndexes firstIndex];
+	NSUInteger column = self.selectedColumnIndexes.firstIndex;
+	NSUInteger row = self.selectedRowIndexes.firstIndex;
 	NSCell *selectedCell = [self _cellForColumn:column row:row];
 
 	[contentView editSelectedCell:self text:aString];
 	
 	if ([selectedCell isKindOfClass:[MBTableGridCell class]]) {
 		// Insert the typed string into the field editor
-		NSText *fieldEditor = [[self window] fieldEditor:YES forObject:contentView];
+		NSText *fieldEditor = [self.window fieldEditor:YES forObject:contentView];
 		fieldEditor.delegate = contentView;
-		[fieldEditor setString:aString];
+		fieldEditor.string = aString;
 		
 		// The textDidBeginEditing notification isn't sent yet, so invoke a custom method
 		[contentView textDidBeginEditingWithEditor:fieldEditor];
 	}
-	[self setNeedsDisplay:YES];
+	self.needsDisplay = YES;
 }
 
 #pragma mark -
@@ -1069,7 +1069,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	}
 	else {
 		if ([self.dataSource respondsToSelector:@selector(tableGrid:validateDrop:proposedColumn:row:)]) {
-			NSPoint mouseLocation = [self convertPoint:[sender draggingLocation] fromView:nil];
+			NSPoint mouseLocation = [self convertPoint:sender.draggingLocation fromView:nil];
 			NSUInteger dropColumn = [self columnAtPoint:mouseLocation];
 			NSUInteger dropRow = [self rowAtPoint:mouseLocation];
 
@@ -1210,16 +1210,16 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 			if (didDrag) {
 				NSUInteger startIndex = dropColumn;
-				NSUInteger length = [draggedColumns count];
+				NSUInteger length = draggedColumns.count;
 
-				if (dropColumn > [draggedColumns firstIndex]) {
-					startIndex -= [draggedColumns count];
+				if (dropColumn > draggedColumns.firstIndex) {
+					startIndex -= draggedColumns.count;
 				}
 
 				NSIndexSet *newColumns = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, length)];
 
 				// Post the notification
-				[[NSNotificationCenter defaultCenter] postNotificationName:MBTableGridDidMoveColumnsNotification object:self userInfo:@{ @"OldColumns": draggedColumns, @"NewColumns": newColumns }];
+				[NSNotificationCenter.defaultCenter postNotificationName:MBTableGridDidMoveColumnsNotification object:self userInfo:@{ @"OldColumns": draggedColumns, @"NewColumns": newColumns }];
 
 				// Change the selection to reflect the newly-dragged columns
 				self.selectedColumnIndexes = newColumns;
@@ -1242,16 +1242,16 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 			if (didDrag) {
 				NSUInteger startIndex = dropRow;
-				NSUInteger length = [draggedRows count];
+				NSUInteger length = draggedRows.count;
 
-				if (dropRow > [draggedRows firstIndex]) {
-					startIndex -= [draggedRows count];
+				if (dropRow > draggedRows.firstIndex) {
+					startIndex -= draggedRows.count;
 				}
 
 				NSIndexSet *newRows = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, length)];
 
 				// Post the notification
-				[[NSNotificationCenter defaultCenter] postNotificationName:MBTableGridDidMoveRowsNotification object:self userInfo:@{ @"OldRows": draggedRows, @"NewRows": newRows }];
+				[NSNotificationCenter.defaultCenter postNotificationName:MBTableGridDidMoveRowsNotification object:self userInfo:@{ @"OldRows": draggedRows, @"NewRows": newRows }];
 
 				// Change the selection to reflect the newly-dragged rows
 				self.selectedRowIndexes = newRows;
@@ -1323,28 +1323,28 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
     NSUInteger lastRow = (_numberOfRows>0) ? _numberOfRows-1 : 0;
 	NSRect bottomRightCellFrame = [contentView frameOfCellAtColumn:lastColumn row:lastRow];
 
-	NSRect contentRect = NSMakeRect([contentView frame].origin.x, [contentView frame].origin.y, NSMaxX(bottomRightCellFrame), NSMaxY(bottomRightCellFrame));
+	NSRect contentRect = NSMakeRect(contentView.frame.origin.x, contentView.frame.origin.y, NSMaxX(bottomRightCellFrame), NSMaxY(bottomRightCellFrame));
 	[contentView setFrameSize:contentRect.size];
 
 	// Update the column header view's size
-	NSRect columnHeaderFrame = [columnHeaderView frame];
+	NSRect columnHeaderFrame = columnHeaderView.frame;
 	columnHeaderFrame.size.width = contentRect.size.width;
-	if(![[contentScrollView verticalScroller] isHidden]) {
-		columnHeaderFrame.size.width += [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];	}
+    if (!contentScrollView.verticalScroller.isHidden) {
+        columnHeaderFrame.size.width += [NSScroller scrollerWidthForControlSize:NSControlSizeRegular scrollerStyle:NSScrollerStyleLegacy];	}
 	[columnHeaderView setFrameSize:columnHeaderFrame.size];
 
 	// Update the row header view's size
-	NSRect rowHeaderFrame = [rowHeaderView frame];
+	NSRect rowHeaderFrame = rowHeaderView.frame;
 	rowHeaderFrame.size.height = contentRect.size.height;
-	if(![[contentScrollView horizontalScroller] isHidden]) {
-		columnHeaderFrame.size.height += [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];
+    if (!contentScrollView.horizontalScroller.isHidden) {
+        columnHeaderFrame.size.height += [NSScroller scrollerWidthForControlSize:NSControlSizeRegular scrollerStyle:NSScrollerStyleLegacy];
 	}
 	[rowHeaderView setFrameSize:rowHeaderFrame.size];
 
-	NSRect columnFooterFrame = [columnFooterView frame];
+	NSRect columnFooterFrame = columnFooterView.frame;
 	columnFooterFrame.size.width = contentRect.size.width;
-	if (![[contentScrollView verticalScroller] isHidden]) {
-		columnFooterFrame.size.width += [NSScroller scrollerWidthForControlSize:NSRegularControlSize
+    if (!contentScrollView.verticalScroller.isHidden) {
+        columnFooterFrame.size.width += [NSScroller scrollerWidthForControlSize:NSControlSizeRegular
 																  scrollerStyle:NSScrollerStyleOverlay];
 	}
 	[columnFooterView setFrameSize:columnHeaderFrame.size];
@@ -1368,12 +1368,12 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	NSRect rect = [self convertRect:[contentView rectOfColumn:columnIndex] fromView:contentView];
 	rect.origin.y = 0;
 	rect.size.height += MBTableGridColumnHeaderHeight;
-	if (rect.size.height > [self frame].size.height) {
-		rect.size.height = [self frame].size.height;
+	if (rect.size.height > self.frame.size.height) {
+		rect.size.height = self.frame.size.height;
 
 		// If the scrollbar is visible, don't include it in the rect
-		if(![[contentScrollView horizontalScroller] isHidden]) {
-			rect.size.height -= [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];
+        if(!contentScrollView.horizontalScroller.isHidden) {
+            rect.size.height -= [NSScroller scrollerWidthForControlSize:NSControlSizeRegular scrollerStyle:NSScrollerStyleLegacy];
 		}
 	}
 
@@ -1423,7 +1423,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (NSRect)footerRectOfCorner {
-	NSRect rect = NSMakeRect(0, [self frame].size.height - MBTableGridColumnHeaderHeight, MBTableGridRowHeaderWidth, MBTableGridColumnHeaderHeight);
+	NSRect rect = NSMakeRect(0, self.frame.size.height - MBTableGridColumnFooterHeight, MBTableGridRowHeaderWidth, MBTableGridColumnFooterHeight);
 	return rect;
 }
 
@@ -1492,7 +1492,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 	// Post the notification
 	if(notify) {
-		[[NSNotificationCenter defaultCenter] postNotificationName:MBTableGridDidChangeSelectionNotification object:self];
+		[NSNotificationCenter.defaultCenter postNotificationName:MBTableGridDidChangeSelectionNotification object:self];
 	}
 }
 
@@ -1522,7 +1522,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	
 	// Post the notification
 	if(notify) {
-		[[NSNotificationCenter defaultCenter] postNotificationName:MBTableGridDidChangeSelectionNotification object:self];
+		[NSNotificationCenter.defaultCenter postNotificationName:MBTableGridDidChangeSelectionNotification object:self];
 	}
 }
 
@@ -1532,22 +1532,22 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 	if (delegate) {
 		// Unregister the delegate for relevant notifications
-		[[NSNotificationCenter defaultCenter] removeObserver:delegate name:MBTableGridDidChangeSelectionNotification object:self];
-		[[NSNotificationCenter defaultCenter] removeObserver:delegate name:MBTableGridDidMoveColumnsNotification object:self];
-		[[NSNotificationCenter defaultCenter] removeObserver:delegate name:MBTableGridDidMoveRowsNotification object:self];
+		[NSNotificationCenter.defaultCenter removeObserver:delegate name:MBTableGridDidChangeSelectionNotification object:self];
+		[NSNotificationCenter.defaultCenter removeObserver:delegate name:MBTableGridDidMoveColumnsNotification object:self];
+		[NSNotificationCenter.defaultCenter removeObserver:delegate name:MBTableGridDidMoveRowsNotification object:self];
 	}
 
 	delegate = anObject;
 
 	// Register the new delegate for relevant notifications
 	if ([delegate respondsToSelector:@selector(tableGridDidChangeSelection:)]) {
-		[[NSNotificationCenter defaultCenter] addObserver:delegate selector:@selector(tableGridDidChangeSelection:) name:MBTableGridDidChangeSelectionNotification object:self];
+		[NSNotificationCenter.defaultCenter addObserver:delegate selector:@selector(tableGridDidChangeSelection:) name:MBTableGridDidChangeSelectionNotification object:self];
 	}
 	if ([delegate respondsToSelector:@selector(tableGridDidMoveColumns:)]) {
-		[[NSNotificationCenter defaultCenter] addObserver:delegate selector:@selector(tableGridDidMoveColumns:) name:MBTableGridDidMoveColumnsNotification object:self];
+		[NSNotificationCenter.defaultCenter addObserver:delegate selector:@selector(tableGridDidMoveColumns:) name:MBTableGridDidMoveColumnsNotification object:self];
 	}
 	if ([delegate respondsToSelector:@selector(tableGridDidMoveRows:)]) {
-		[[NSNotificationCenter defaultCenter] addObserver:delegate selector:@selector(tableGridDidMoveRows:) name:MBTableGridDidMoveRowsNotification object:self];
+		[NSNotificationCenter.defaultCenter addObserver:delegate selector:@selector(tableGridDidMoveRows:) name:MBTableGridDidMoveRowsNotification object:self];
 	}
 }
 
@@ -1590,7 +1590,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (float)_widthForColumn:(NSUInteger)columnIndex {
 	if (columnIndexNames.count > columnIndex) {
-		NSNumber* width = [_columnWidths objectForKey:@(columnIndex)];
+		NSNumber* width = _columnWidths[@(columnIndex)];
 		return width == nil ? MBTableHeaderMinimumColumnWidth : width.floatValue;
 	}
 	
@@ -1599,7 +1599,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (void) _setWidth:(float)width forColumn:(NSUInteger)columnIndex
 {
-	[_columnWidths setObject:@(width) forKey:@(columnIndex)];
+    _columnWidths[@(columnIndex)] = @(width);
 	
 	if ([self.dataSource respondsToSelector:@selector(tableGrid:setWidth:forColumn:)]) {
 		[self.dataSource tableGrid:self setWidth:width forColumn:columnIndex];
@@ -1683,7 +1683,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 - (void)_dragColumnsWithEvent:(NSEvent *)theEvent {
 	NSImage *dragImage = [self _imageForSelectedColumns];
 
-	NSRect firstSelectedColumn = [self rectOfColumn:[self.selectedColumnIndexes firstIndex]];
+	NSRect firstSelectedColumn = [self rectOfColumn:self.selectedColumnIndexes.firstIndex];
 	NSPoint location = firstSelectedColumn.origin;
     
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self.selectedColumnIndexes];
@@ -1700,7 +1700,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 - (void)_dragRowsWithEvent:(NSEvent *)theEvent {
 	NSImage *dragImage = [self _imageForSelectedRows];
     
-	NSRect firstSelectedRow = [self rectOfRow:[self.selectedRowIndexes firstIndex]];
+	NSRect firstSelectedRow = [self rectOfRow:self.selectedRowIndexes.firstIndex];
 	NSPoint location = firstSelectedRow.origin;
     
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self.selectedRowIndexes];
@@ -1726,12 +1726,12 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	NSImage *opaqueImage = [[NSImage alloc] initWithData:[self dataWithPDFInsideRect:columnsFrame]];
 
 	// Create the translucent drag image
-	NSImage *finalImage = [[NSImage alloc] initWithSize:[opaqueImage size]];
+	NSImage *finalImage = [[NSImage alloc] initWithSize:opaqueImage.size];
 	[finalImage lockFocus];
 #if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_8
 	[opaqueImage compositeToPoint:NSZeroPoint operation:NSCompositeCopy fraction:0.7];
 #else
-	[opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositeCopy fraction:0.7];
+    [opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:0.7];
 #endif
 	[finalImage unlockFocus];
 
@@ -1750,12 +1750,12 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	NSImage *opaqueImage = [[NSImage alloc] initWithData:[self dataWithPDFInsideRect:rowsFrame]];
 
 	// Create the translucent drag image
-	NSImage *finalImage = [[NSImage alloc] initWithSize:[opaqueImage size]];
+	NSImage *finalImage = [[NSImage alloc] initWithSize:opaqueImage.size];
 	[finalImage lockFocus];
 #if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_8
 	[opaqueImage compositeToPoint:NSZeroPoint operation:NSCompositeCopy fraction:0.7];
 #else
-	[opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositeCopy fraction:0.7];
+    [opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:0.7];
 #endif
 	[finalImage unlockFocus];
 

--- a/MBTableGridContentView.h
+++ b/MBTableGridContentView.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, MBTableGridTrackingPart)
 	
 	MBTableGridCell *_defaultCell;
     
-    NSMutableArray *columnWidths;
+    NSMutableArray<NSNumber *> *columnWidths;
     
 }
 

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -103,11 +103,11 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		
 		self.wantsLayer = true;
 		self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
-		[self.layer setDrawsAsynchronously:YES];
+		self.layer.drawsAsynchronously = YES;
 		_defaultCell = [[MBTableGridCell alloc] initTextCell:@""];
-        [_defaultCell setBordered:YES];
-		[_defaultCell setScrollable:YES];
-		[_defaultCell setLineBreakMode:NSLineBreakByTruncatingTail];
+        _defaultCell.bordered = YES;
+        _defaultCell.scrollable = YES;
+        _defaultCell.lineBreakMode = NSLineBreakByTruncatingTail;
 	}
 	return self;
 }
@@ -120,8 +120,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 - (void)drawRect:(NSRect)rect
 {
     
-    NSIndexSet *selectedColumns = [_tableGrid selectedColumnIndexes];
-    NSIndexSet *selectedRows = [_tableGrid selectedRowIndexes];
+    NSIndexSet *selectedColumns = _tableGrid.selectedColumnIndexes;
+    NSIndexSet *selectedRows = _tableGrid.selectedRowIndexes;
 	NSUInteger numberOfColumns = _tableGrid.numberOfColumns;
 	NSUInteger numberOfRows = _tableGrid.numberOfRows;
 	
@@ -174,36 +174,36 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		//[translate translateXBy:-0.5 yBy:-0.5];
 		[selectionPath transformUsingAffineTransform:translate];
 		
-		NSColor *selectionColor = [NSColor alternateSelectedControlColor];
+		NSColor *selectionColor = NSColor.alternateSelectedControlColor;
 		
 		// If the view is not the first responder, then use a gray selection color
 		NSResponder *firstResponder = [self.window firstResponder];
 		BOOL disabled = (![firstResponder.class isSubclassOfClass:NSView.class] || ![(NSView *)firstResponder isDescendantOf:_tableGrid] || !self.window.isKeyWindow);
 		
 		if (disabled) {
-			selectionColor = [[selectionColor colorUsingColorSpaceName:NSDeviceWhiteColorSpace] colorUsingColorSpaceName:NSDeviceRGBColorSpace];
+            selectionColor = [[selectionColor colorUsingColorSpace:NSColorSpace.genericGrayColorSpace] colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
         } else if (isFilling) {
             selectionColor = [NSColor colorWithCalibratedRed:0.996 green:0.827 blue:0.176 alpha:1.000];
         }
 		
 		[[selectionColor colorWithAlphaComponent:0.3] set];
-		[selectionPath setLineWidth: 1.0];
+		selectionPath.lineWidth = 1.0;
 		[selectionPath stroke];
         
         [[selectionColor colorWithAlphaComponent:0.2f] set];
         [selectionPath fill];
         
-		if (!showsGrabHandle || disabled || [selectedColumns count] > 1) {
+		if (!showsGrabHandle || disabled || selectedColumns.count > 1) {
 			grabHandleRect = NSZeroRect;
 		}
         else if (shouldDrawFillPart != MBTableGridTrackingPartNone) {
             // Draw grab handle
             grabHandleRect = NSMakeRect(NSMidX(selectionInsetRect) - kGRAB_HANDLE_HALF_SIDE_LENGTH - 2, (shouldDrawFillPart == MBTableGridTrackingPartFillTop ? NSMinY(selectionInsetRect) : NSMaxY(selectionInsetRect)) - kGRAB_HANDLE_HALF_SIDE_LENGTH - 2, kGRAB_HANDLE_SIDE_LENGTH + 4, kGRAB_HANDLE_SIDE_LENGTH + 4);
-            [grabHandleImage drawInRect:grabHandleRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
+            [grabHandleImage drawInRect:grabHandleRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
         }
 		
         // Inavlidate cursors so we use the correct cursor for the selection in the right place
-        [[self window] invalidateCursorRectsForView:self];
+        [self.window invalidateCursorRectsForView:self];
 	}
 	
 	// Draw the column drop indicator
@@ -222,10 +222,10 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		columnBorder.origin.x = NSMinX(columnBorder)-2.0;
 		columnBorder.size.width = 4.0;
 		
-		NSColor *selectionColor = [NSColor alternateSelectedControlColor];
+		NSColor *selectionColor = NSColor.alternateSelectedControlColor;
 		
 		NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:columnBorder];
-		[borderPath setLineWidth:2.0];
+		borderPath.lineWidth = 2.0;
 		
 		[selectionColor set];
 		[borderPath stroke];
@@ -243,10 +243,10 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		rowBorder.origin.y = NSMinY(rowBorder)-2.0;
 		rowBorder.size.height = 4.0;
 		
-		NSColor *selectionColor = [NSColor alternateSelectedControlColor];
+		NSColor *selectionColor = NSColor.alternateSelectedControlColor;
 		
 		NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:rowBorder];
-		[borderPath setLineWidth:2.0];
+		borderPath.lineWidth = 2.0;
 		
 		[selectionColor set];
 		[borderPath stroke];
@@ -262,7 +262,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		
 		NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:NSInsetRect(cellFrame, 2, 2)];
 		
-		NSColor *dropColor = [NSColor alternateSelectedControlColor];
+		NSColor *dropColor = NSColor.alternateSelectedControlColor;
 		[dropColor set];
 		
 		borderPath.lineWidth = 2.0;
@@ -304,8 +304,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		// Pass the event back to the MBTableGrid (Used to give First Responder status)
 		[self.tableGrid mouseDown:theEvent];
 		
-		NSUInteger selectedColumn = [self.tableGrid.selectedColumnIndexes firstIndex];
-		NSUInteger selectedRow = [self.tableGrid.selectedRowIndexes firstIndex];
+		NSUInteger selectedColumn = self.tableGrid.selectedColumnIndexes.firstIndex;
+		NSUInteger selectedRow = self.tableGrid.selectedRowIndexes.firstIndex;
 
         isFilling = showsGrabHandle && NSPointInRect(mouseLocationInContentView, grabHandleRect);
         
@@ -322,20 +322,20 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 			[self editSelectedCell:self text:nil];
 
 		// Expand a selection when the user holds the shift key
-		} else if (([theEvent modifierFlags] & NSShiftKeyMask) && self.tableGrid.allowsMultipleSelection && !isFilling) {
+        } else if ((theEvent.modifierFlags & NSEventModifierFlagShift) && self.tableGrid.allowsMultipleSelection && !isFilling) {
 			// If the shift key was held down, extend the selection
-			NSUInteger stickyColumn = [self.tableGrid.selectedColumnIndexes firstIndex];
-			NSUInteger stickyRow = [self.tableGrid.selectedRowIndexes firstIndex];
+			NSUInteger stickyColumn = self.tableGrid.selectedColumnIndexes.firstIndex;
+			NSUInteger stickyRow = self.tableGrid.selectedRowIndexes.firstIndex;
 
 			MBHorizontalEdge stickyColumnEdge = [self.tableGrid _stickyColumn];
 			MBVerticalEdge stickyRowEdge = [self.tableGrid _stickyRow];
 			
 			// Compensate for sticky edges
 			if (stickyColumnEdge == MBHorizontalEdgeRight) {
-				stickyColumn = [self.tableGrid.selectedColumnIndexes lastIndex];
+				stickyColumn = self.tableGrid.selectedColumnIndexes.lastIndex;
 			}
 			if (stickyRowEdge == MBVerticalEdgeBottom) {
-				stickyRow = [self.tableGrid.selectedRowIndexes lastIndex];
+				stickyRow = self.tableGrid.selectedRowIndexes.lastIndex;
 			}
 			
 			NSRange selectionColumnRange = NSMakeRange(stickyColumn, mouseDownColumn-stickyColumn+1);
@@ -377,7 +377,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		[self editSelectedCell:self text:nil];
 	}
 
-	[self setNeedsDisplay:YES];
+	self.needsDisplay = YES;
 }
 
 - (void)mouseDragged:(NSEvent *)theEvent
@@ -451,7 +451,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		// Set the sticky edges
 		[self.tableGrid _setStickyColumn:columnEdge row:rowEdge];
 		
-        [self setNeedsDisplay:YES];
+        self.needsDisplay = YES;
 	}
 }
 
@@ -478,7 +478,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
         
 		isFilling = NO;
         
-        [self.tableGrid setNeedsDisplay:YES];
+        self.tableGrid.needsDisplay = YES;
 	}
 	
 	mouseDownColumn = NSNotFound;
@@ -488,7 +488,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 
 - (void)mouseEntered:(NSEvent *)theEvent
 {
-    NSDictionary *dict = theEvent.userData;
+    NSDictionary<NSString *, id> *dict = theEvent.userData;
     MBTableGridTrackingPart part = [dict[MBTableGridTrackingPartKey] integerValue];
     
     if (shouldDrawFillPart != part) {
@@ -512,8 +512,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	NSIndexSet *selectedRows = self.tableGrid.selectedRowIndexes;
 
 	if (selectedColumns.count > 0 && selectedRows.count > 0) {
-		NSRect selectionTopLeft = [self frameOfCellAtColumn:[selectedColumns firstIndex] row:[selectedRows firstIndex]];
-		NSRect selectionBottomRight = [self frameOfCellAtColumn:[selectedColumns lastIndex] row:[selectedRows lastIndex]];
+		NSRect selectionTopLeft = [self frameOfCellAtColumn:selectedColumns.firstIndex row:selectedRows.firstIndex];
+        NSRect selectionBottomRight = [self frameOfCellAtColumn:selectedColumns.lastIndex row:selectedRows.lastIndex];
 
 		NSRect selectionRect;
 		selectionRect.origin = selectionTopLeft.origin;
@@ -528,7 +528,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		}
 
 		if (selectedColumns.count == 1 && CGRectIntersectsRect(self.visibleRect, selectionRect)) {
-			NSRect fillTrackingRect = [self rectOfColumn:[selectedColumns firstIndex]];
+			NSRect fillTrackingRect = [self rectOfColumn:selectedColumns.firstIndex];
 			fillTrackingRect = CGRectIntersection(fillTrackingRect, self.visibleRect);
 			fillTrackingRect.size.height = self.frame.size.height;
 			NSRect topFillTrackingRect, bottomFillTrackingRect;
@@ -550,7 +550,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 }
 
 - (void) resetCursorRects {
-    [self addCursorRect:[self visibleRect] cursor:[self _cellSelectionCursor]];
+    [self addCursorRect:self.visibleRect cursor:[self _cellSelectionCursor]];
 }
 
 #pragma mark -
@@ -579,10 +579,10 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	NSInteger movementType = [aNotification.userInfo[@"NSTextMovement"] integerValue];
 
 	// Give focus back to the table grid (the field editor took it)
-	[[self window] makeFirstResponder:self.tableGrid];
+	[self.window makeFirstResponder:self.tableGrid];
 
 	if(movementType != NSCancelTextMovement) {
-		NSString *stringValue = [[[aNotification object] string] copy];
+		NSString *stringValue = [[aNotification.object string] copy];
 		[self.tableGrid _setObjectValue:stringValue forColumn:editedColumn row:editedRow];
 	}
 
@@ -590,8 +590,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	editedRow = NSNotFound;
 	
 	// End the editing session
-	NSText* fe = [[self window] fieldEditor:NO forObject:self];
-	[[self.tableGrid cell] endEditing:fe];
+	NSText* fe = [self.window fieldEditor:NO forObject:self];
+	[self.tableGrid.cell endEditing:fe];
 
 
 	switch (movementType) {
@@ -604,7 +604,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 			break;
 
 		case NSReturnTextMovement:
-			if([NSApp currentEvent].modifierFlags & NSShiftKeyMask) {
+            if(NSApp.currentEvent.modifierFlags & NSEventModifierFlagShift) {
 				[self.tableGrid moveUp:self];
 			}
 			else {
@@ -620,8 +620,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 			break;
 	}
 
-	[fe setAlignment:NSTextAlignmentNatural];
-	[[self window] endEditingFor:self];
+	fe.alignment = NSTextAlignmentNatural;
+	[self.window endEditingFor:self];
 }
 
 #pragma mark -
@@ -688,8 +688,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 
 - (void)editSelectedCell:(id)sender text:(NSString *)aString
 {
-	NSInteger selectedColumn = [self.tableGrid.selectedColumnIndexes firstIndex];
-	NSInteger selectedRow = [self.tableGrid.selectedRowIndexes firstIndex];
+	NSInteger selectedColumn = self.tableGrid.selectedColumnIndexes.firstIndex;
+	NSInteger selectedRow = self.tableGrid.selectedRowIndexes.firstIndex;
 	NSCell *selectedCell = [self.tableGrid _cellForColumn:selectedColumn row: selectedRow];
 
 	// Check if the cell can be edited
@@ -700,10 +700,10 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	}
 
 	// Select it and only it
-	if([self.tableGrid.selectedColumnIndexes count] > 1 && editedColumn != NSNotFound) {
+	if (self.tableGrid.selectedColumnIndexes.count > 1 && editedColumn != NSNotFound) {
 		self.tableGrid.selectedColumnIndexes = [NSIndexSet indexSetWithIndex:editedColumn];
 	}
-	if([self.tableGrid.selectedRowIndexes count] > 1 && editedRow != NSNotFound) {
+	if (self.tableGrid.selectedRowIndexes.count > 1 && editedRow != NSNotFound) {
 		self.tableGrid.selectedRowIndexes = [NSIndexSet indexSetWithIndex:editedRow];
 	}
 
@@ -713,8 +713,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 
 	NSRect cellFrame = [self frameOfCellAtColumn:editedColumn row:editedRow];
 
-	[selectedCell setEditable:YES];
-	[selectedCell setSelectable:YES];
+	selectedCell.editable = YES;
+	selectedCell.selectable = YES;
 	
 	id currentValue = [self.tableGrid _objectValueForColumn:editedColumn row:editedRow];
 
@@ -724,9 +724,9 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	editor.font = selectedCell.font;
 	selectedCell.stringValue = currentValue;
 	editor.string = currentValue;
-	NSEvent* event = [NSApp currentEvent];
-	if(event != nil && event.type == NSLeftMouseDown) {
-		[selectedCell editWithFrame:cellFrame inView:self editor:editor delegate:self event:[NSApp currentEvent]];
+	NSEvent* event = NSApp.currentEvent;
+    if(event != nil && event.type == NSEventTypeLeftMouseDown) {
+		[selectedCell editWithFrame:cellFrame inView:self editor:editor delegate:self event:event];
 	}
 	else {
 		[selectedCell selectWithFrame:cellFrame inView:self editor:editor delegate:self start:0 length:[currentValue length]];
@@ -742,14 +742,14 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	if (columnIndex < self.tableGrid.numberOfColumns) {
 		NSValue *cachedRectValue = self.tableGrid.columnRects[@(columnIndex)];
 		if (cachedRectValue) {
-			rect = [cachedRectValue rectValue];
+			rect = cachedRectValue.rectValue;
 			foundRect = YES;
 		}
 	
 		if (!foundRect) {
 			float width = [self.tableGrid _widthForColumn:columnIndex];
 			
-			rect = NSMakeRect(0, 0, width, [self frame].size.height);
+			rect = NSMakeRect(0, 0, width, self.frame.size.height);
 			//rect.origin.x += 60.0 * columnIndex;
 			
 			NSUInteger i = 0;
@@ -769,7 +769,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 
 - (NSRect)rectOfRow:(NSUInteger)rowIndex
 {
-	NSRect rect = NSMakeRect(0, 0, [self frame].size.width, self.rowHeight);
+	NSRect rect = NSMakeRect(0, 0, self.frame.size.width, self.rowHeight);
 	rect.origin.y += self.rowHeight * rowIndex;
 	return rect;
 }
@@ -831,25 +831,25 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	
 	// Set the shadow
 	NSShadow *shadow = [[NSShadow alloc] init];
-	[shadow setShadowColor:[NSColor colorWithDeviceWhite:0.0 alpha:0.8]];
-	[shadow setShadowBlurRadius:2.0];
-	[shadow setShadowOffset:NSMakeSize(0, -1.0)];
+	shadow.shadowColor = [NSColor colorWithCalibratedWhite:0.0 alpha:0.8];
+	shadow.shadowBlurRadius = 2.0;
+	shadow.shadowOffset = NSMakeSize(0, -1.0);
 	
-	[[NSGraphicsContext currentContext] saveGraphicsState];
+	[NSGraphicsContext.currentContext saveGraphicsState];
 	
 	[shadow set];
 	
-	[[NSColor blackColor] set];
+	[NSColor.blackColor set];
 	NSRectFill(horizontalOuter);
 	NSRectFill(verticalOuter);
 	
-	[[NSGraphicsContext currentContext] restoreGraphicsState];
+	[NSGraphicsContext.currentContext restoreGraphicsState];
 	
 	// Fill them again to compensate for the shadows
 	NSRectFill(horizontalOuter);
 	NSRectFill(verticalOuter);
 	
-	[[NSColor whiteColor] set];
+	[NSColor.whiteColor set];
 	NSRectFill(horizontalInner);
 	NSRectFill(verticalInner);
 	
@@ -880,19 +880,19 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	NSRect horizontalOuter = NSInsetRect(horizontalInner, -1.0, -1.0);
 	NSRect verticalOuter = NSInsetRect(verticalInner, -1.0, -1.0);
 	
-	[[NSGraphicsContext currentContext] saveGraphicsState];
+	[NSGraphicsContext.currentContext saveGraphicsState];
 
-	[[NSColor whiteColor] set];
+	[NSColor.whiteColor set];
 	NSRectFill(horizontalOuter);
 	NSRectFill(verticalOuter);
 	
-	[[NSGraphicsContext currentContext] restoreGraphicsState];
+	[NSGraphicsContext.currentContext restoreGraphicsState];
 	
 	// Fill them again to compensate for the shadows
 	NSRectFill(horizontalOuter);
 	NSRectFill(verticalOuter);
 	
-	[[NSColor blackColor] set];
+	[NSColor.blackColor set];
 	NSRectFill(horizontalInner);
 	NSRectFill(verticalInner);
 	
@@ -913,13 +913,13 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	
 	// Set the color in the current graphics context
 	
-	[[NSColor darkGrayColor] setStroke];
+	[NSColor.darkGrayColor setStroke];
 	[[NSColor colorWithCalibratedRed:0.996 green:0.827 blue:0.176 alpha:1.000] setFill];
 	
 	// Create our circle path
 	NSRect rect = NSMakeRect(1.0, 1.0, kGRAB_HANDLE_SIDE_LENGTH - 2.0, kGRAB_HANDLE_SIDE_LENGTH - 2.0);
 	NSBezierPath *circlePath = [NSBezierPath bezierPath];
-	[circlePath setLineWidth:0.5];
+	circlePath.lineWidth = 0.5;
 	[circlePath appendBezierPathWithOvalInRect: rect];
 	
 	// Outline and fill the path
@@ -945,19 +945,19 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 - (void)_setDropColumn:(NSInteger)columnIndex
 {
 	dropColumn = columnIndex;
-	[self setNeedsDisplay:YES];
+	self.needsDisplay = YES;
 }
 
 - (void)_setDropRow:(NSInteger)rowIndex
 {
 	dropRow = rowIndex;
-	[self setNeedsDisplay:YES];
+	self.needsDisplay = YES;
 }
 
 - (void)_timerAutoscrollCallback:(NSTimer *)aTimer
 {
-	NSEvent* event = [NSApp currentEvent];
-    if ([event type] == NSLeftMouseDragged )
+	NSEvent* event = NSApp.currentEvent;
+    if (NSApp.currentEvent.type == NSEventTypeLeftMouseDragged)
         [self autoscroll:event];
 }
 

--- a/MBTableGridFooterView.m
+++ b/MBTableGridFooterView.m
@@ -42,7 +42,7 @@
     if(self = [super initWithFrame:frameRect]) {
 		self.tableGrid = tableGrid;
         _defaultCell = [[MBFooterTextCell alloc] initTextCell:@""];
-        [_defaultCell setBordered:NO];
+        _defaultCell.bordered = NO;
 		self.wantsLayer = YES;
 		self.layer.drawsAsynchronously = YES;
 		self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
@@ -83,7 +83,7 @@
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
-    NSPoint mouseLocationInContentView = [self convertPoint:[theEvent locationInWindow] fromView:nil];
+    NSPoint mouseLocationInContentView = [self convertPoint:theEvent.locationInWindow fromView:nil];
     NSInteger mouseDownColumn = [self footerColumnAtPoint:mouseLocationInContentView];
     
     if (theEvent.clickCount == 1) {
@@ -96,7 +96,7 @@
 		[self.tableGrid.delegate tableGrid:self.tableGrid footerCellClicked:cell forColumn:mouseDownColumn withEvent:theEvent];
     }
     
-    [self setNeedsDisplay:YES];
+    self.needsDisplay = YES;
 }
 
 - (NSRect)adjustScroll:(NSRect)proposedVisibleRect

--- a/MBTableGridHeaderCell.m
+++ b/MBTableGridHeaderCell.m
@@ -39,21 +39,21 @@
 - (NSColor*)borderColor
 {
 	if (_borderColor == nil)
-		_borderColor = [NSColor gridColor];
+		_borderColor = NSColor.gridColor;
 	return _borderColor;
 }
 
 - (NSColor*)textColor
 {
 	if (_textColor == nil)
-		_textColor = [NSColor headerTextColor];
+		_textColor = NSColor.headerTextColor;
 	return _textColor;
 }
 
 - (NSFont*)labelFont
 {
 	if (_labelFont == nil)
-		_labelFont = [NSFont labelFontOfSize:[NSFont labelFontSize]];
+		_labelFont = [NSFont labelFontOfSize:NSFont.labelFontSize];
 	return _labelFont;
 }
 
@@ -61,7 +61,7 @@
 {
 	NSRect cellFrameRect = cellFrame;
 	
-	[[NSColor windowBackgroundColor] set];
+	[NSColor.windowBackgroundColor set];
 	NSRectFill(cellFrame);
 		
 	if(self.orientation == MBTableHeaderHorizontalOrientation) {
@@ -85,7 +85,7 @@
 		NSRectFill(bottomLine);
 	}
 	
-	if([self state] == NSOnState) {
+    if(self.state == NSControlStateValueOn) {
 		NSRect fillRect = cellFrameRect;
 		if(self.orientation == MBTableHeaderVerticalOrientation) {
 			fillRect.origin.y -= 1.0;
@@ -100,7 +100,7 @@
 		}
 		NSBezierPath* path = [NSBezierPath bezierPathWithRoundedRect:fillRect xRadius:4.0 yRadius:4.0];
 
-		NSColor *overlayColor = [[NSColor alternateSelectedControlColor] colorWithAlphaComponent:0.26];
+		NSColor *overlayColor = [NSColor.alternateSelectedControlColor colorWithAlphaComponent:0.26];
 		[overlayColor set];
 		[path fill];
 	}
@@ -110,7 +110,7 @@
 }
 
 - (NSAttributedString *)attributedStringValue {
-	NSDictionary *attributes = @{
+	NSDictionary<NSAttributedStringKey, id> *attributes = @{
 		NSFontAttributeName: self.labelFont,
 		NSForegroundColorAttributeName: self.textColor
 	};

--- a/MBTableGridHeaderView.h
+++ b/MBTableGridHeaderView.h
@@ -49,7 +49,7 @@
     BOOL isResizing;
     NSUInteger draggingColumnIndex;
 	
-	NSMutableDictionary *columnAutoSaveProperties;
+	NSMutableDictionary<NSString *, NSDictionary<NSString *, id> *> *columnAutoSaveProperties;
 	
 }
 
@@ -97,7 +97,7 @@
 /**
  * @brief		The column to set the indicator image on
  */
-@property (nonatomic, strong) NSArray *indicatorImageColumns;
+@property (nonatomic, strong) NSArray<NSNumber *> *indicatorImageColumns;
 
 /**
  * @brief		The autosave name for this grid

--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -73,7 +73,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 
 - (void)placeSortButtons
 {
-	NSMutableArray *capturingButtons = [NSMutableArray arrayWithCapacity:0];
+	NSMutableArray<NSButton *> *capturingButtons = [NSMutableArray arrayWithCapacity:0];
 
 	NSButton *sortButton;
 
@@ -83,7 +83,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 		sortButton.image = self.indicatorImage;
 		sortButton.alternateImage = self.indicatorReverseImage;
 		sortButton.bordered = NO;
-		sortButton.state = NSOnState;
+        sortButton.state = NSControlStateValueOn;
 		sortButton.tag = cellNumber.integerValue;
 		sortButton.target = self.tableGrid;
 		sortButton.action = @selector(sortButtonClicked:);
@@ -140,7 +140,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 	if (self.orientation == MBTableHeaderHorizontalOrientation) {
 		// Draw the column headers
 		NSUInteger numberOfColumns = self.tableGrid.numberOfColumns;
-		[headerCell setOrientation:self.orientation];
+		headerCell.orientation = self.orientation;
 		NSUInteger column = 0;
 		while (column < numberOfColumns) {
 			NSRect headerRect = [self headerRectOfColumn:column];
@@ -165,7 +165,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 	if (self.orientation == MBTableHeaderHorizontalOrientation) {
 		// Draw the column headers
 		NSUInteger numberOfColumns = self.tableGrid.numberOfColumns;
-		[headerCell setOrientation:self.orientation];
+		headerCell.orientation = self.orientation;
 		NSUInteger column = 0;
 		while (column < numberOfColumns) {
 			NSRect headerRect = [self headerRectOfColumn:column];
@@ -188,7 +188,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 	if (self.orientation == MBTableHeaderHorizontalOrientation) {
 		// Draw the column headers
 		NSUInteger numberOfColumns = self.tableGrid.numberOfColumns;
-		[headerCell setOrientation:self.orientation];
+		headerCell.orientation = self.orientation;
 		NSUInteger column = 0;
 		while (column < numberOfColumns) {
 			NSRect headerRect = [self headerRectOfColumn:column];
@@ -197,12 +197,12 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 			if ([self needsToDrawRect:headerRect]) {
 				// Check if any part of the selection is in this column
 				NSIndexSet *selectedColumns = [self.tableGrid selectedColumnIndexes];
-				headerCell.state = [selectedColumns containsIndex:column] ? NSOnState : NSOffState;
+                headerCell.state = [selectedColumns containsIndex:column] ? NSControlStateValueOn : NSControlStateValueOff;
 				
-				if ([self.indicatorImageColumns containsObject:[NSNumber numberWithInteger:column]]) {
-					[headerCell setSortIndicatorImage:self.indicatorImage];
+				if ([self.indicatorImageColumns containsObject:@(column)]) {
+					headerCell.sortIndicatorImage = self.indicatorImage;
 				} else {
-					[headerCell setSortIndicatorImage:nil];
+					headerCell.sortIndicatorImage = nil;
 				}
 				
 				headerCell.stringValue = [self.tableGrid _headerStringForColumn:column];
@@ -214,7 +214,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 	} else if (self.orientation == MBTableHeaderVerticalOrientation) {
 		// Draw the row headers
 		NSUInteger numberOfRows = self.tableGrid.numberOfRows;
-		[headerCell setOrientation:self.orientation];
+		headerCell.orientation = self.orientation;
 
 		CGFloat rowHeight = [self.tableGrid _contentView].rowHeight;
 		NSUInteger row = MAX(0, floor(rect.origin.y / rowHeight));
@@ -227,7 +227,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 			if ([self needsToDrawRect:headerRect]) {
 				// Check if any part of the selection is in this column
 				NSIndexSet *selectedRows = [self.tableGrid selectedRowIndexes];
-				headerCell.state = [selectedRows containsIndex:row] ? NSOnState : NSOffState;
+                headerCell.state = [selectedRows containsIndex:row] ? NSControlStateValueOn : NSControlStateValueOff;
 				
 				headerCell.stringValue = [self.tableGrid _headerStringForRow:row];
 				[headerCell drawWithFrame:headerRect inView:self];
@@ -264,7 +264,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 		else {
 			// For single clicks,
 			if (theEvent.clickCount == 1) {
-				if ((theEvent.modifierFlags & NSShiftKeyMask) && self.tableGrid.allowsMultipleSelection) {
+                if ((theEvent.modifierFlags & NSEventModifierFlagShift) && self.tableGrid.allowsMultipleSelection) {
 					// If the shift key was held down, extend the selection
 				} else {
 					// No modifier keys, so change the selection
@@ -476,13 +476,13 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 	
 	[self.tableGrid.columnRects enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
 		NSValue *rectValue = obj;
-		NSRect rect = [rectValue rectValue];
-		NSDictionary *columnDict = @{kAutosavedColumnWidthKey : @(rect.size.width),
-									 kAutosavedColumnHiddenKey : @NO};
+		NSRect rect = rectValue.rectValue;
+		NSDictionary<NSString *, id> *columnDict = @{kAutosavedColumnWidthKey : @(rect.size.width),
+                                                     kAutosavedColumnHiddenKey : @NO};
 		columnAutoSaveProperties[[NSString stringWithFormat:@"C-%@", key]] = columnDict;
 	}];
 	
-	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
 	[defaults setObject:columnAutoSaveProperties forKey:self.autosaveName];
 }
 


### PR DESCRIPTION
* Use properties wherever possible
* Use generics wherever possible
* Use literal syntax wherever possible
* Use calibrated colors instead of device colors
* Use updated constant names (e.g. `NSOnState` => `NSControlValueStateOn`)
* `[NSColor colorWithColorSpaceName:]` => `[NSColor colorWithColorSpace:]` (Fix deprecation warning)

Apart from barely-perceptible calibrated vs device color spaces, there should be no change in run-time behavior.