### PR TITLE
Column rect caching fix

### DIFF
--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -764,7 +764,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		}
 	}
 	
-	return rect;
+    return NSMakeRect(rect.origin.x, 0.0, rect.size.width, [self frame].size.height);
 }
 
 - (NSRect)rectOfRow:(NSUInteger)rowIndex


### PR DESCRIPTION
`rectOfColumn:` sometimes returned an incorrect result because the old height was cached along with the width. Keep the cached X-coordinate information, but return a fresh measurement of the frame height.