### PR TITLE
Use a single backing layer for the whole table grid

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -267,6 +267,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		
 		self.columnRects = [NSMutableDictionary dictionary];
         [self registerForDraggedTypes:@[MBTableGridColumnDataType, MBTableGridRowDataType]];
+        self.wantsLayer = YES;
 	}
 	return self;
 }

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -101,9 +101,6 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 
 		_rowHeight = 20.0f;
 		
-		self.wantsLayer = true;
-		self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
-		self.layer.drawsAsynchronously = YES;
 		_defaultCell = [[MBTableGridCell alloc] initTextCell:@""];
         _defaultCell.bordered = YES;
         _defaultCell.scrollable = YES;

--- a/MBTableGridFooterView.m
+++ b/MBTableGridFooterView.m
@@ -43,9 +43,6 @@
 		self.tableGrid = tableGrid;
         _defaultCell = [[MBFooterTextCell alloc] initTextCell:@""];
         _defaultCell.bordered = NO;
-		self.wantsLayer = YES;
-		self.layer.drawsAsynchronously = YES;
-		self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
     }
     return self;
 }

--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -50,9 +50,6 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 {
 	if(self = [super initWithFrame:frameRect]) {
 		self.tableGrid = tableGrid;
-		self.wantsLayer = YES;
-		self.layer.drawsAsynchronously = YES;
-		self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
 		
 		// Setup the header cell
 		headerCell = [[MBTableGridHeaderCell alloc] init];


### PR DESCRIPTION
It's not really necessary for the subviews to have backing layers, as they'll be composited into the layer of a shared ancestor. The asynchronous drawing stuff is probably not needed as the table grid is now quite performant. (In fact maybe layer backing is not necessary at all at this point.)

Fixes #27