### PR TITLE
Basic Find / Replace support

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -142,10 +142,13 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
 	MBVerticalEdge stickyRowEdge;
 	NSMutableArray<NSString *> *columnIndexNames;
 	NSMutableDictionary<NSNumber *, NSNumber *>* _columnWidths;
-	
+
+    NSTextFinder *_textFinder;
+    id<NSTextFinderClient> _textFinderClient;
 }
 
 @property (nonatomic, assign) BOOL showsGrabHandles;
+@property (getter=isFindBarVisible) BOOL findBarVisible;
 
 @property (nonatomic, readonly) MBTableGridHeaderView* columnHeaderView;
 @property (nonatomic, readonly) MBTableGridFooterView* columnFooterView;

--- a/MBTableGrid.xcodeproj/project.pbxproj
+++ b/MBTableGrid.xcodeproj/project.pbxproj
@@ -26,6 +26,12 @@
 		C6BF26891A4AC502008EB93F /* MBTableGridFooterView.h in Headers */ = {isa = PBXBuildFile; fileRef = C6BF26881A4AC502008EB93F /* MBTableGridFooterView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C9412A5F0D8AE98C00E9E614 /* MBTableGridController.m in Sources */ = {isa = PBXBuildFile; fileRef = C9412A5E0D8AE98C00E9E614 /* MBTableGridController.m */; };
 		CA46E3621A09726A00C43B4B /* MBTableGridEditable.h in Headers */ = {isa = PBXBuildFile; fileRef = CA46E3611A09726A00C43B4B /* MBTableGridEditable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC7EBF4123D2157B00F75351 /* MBTableGridContentScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7EBF3F23D2157B00F75351 /* MBTableGridContentScrollView.h */; };
+		DC7EBF4223D2157B00F75351 /* MBTableGridContentScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7EBF4023D2157B00F75351 /* MBTableGridContentScrollView.m */; };
+		DC7EBF4523D217DC00F75351 /* MBTableGridVirtualString.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7EBF4323D217DC00F75351 /* MBTableGridVirtualString.h */; };
+		DC7EBF4623D217DC00F75351 /* MBTableGridVirtualString.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7EBF4423D217DC00F75351 /* MBTableGridVirtualString.m */; };
+		DC7EBF4923D21AE800F75351 /* MBTableGridTextFinderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7EBF4723D21AE800F75351 /* MBTableGridTextFinderClient.h */; };
+		DC7EBF4A23D21AE800F75351 /* MBTableGridTextFinderClient.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7EBF4823D21AE800F75351 /* MBTableGridTextFinderClient.m */; };
 		DCDB6EDB23C905C200F348EB /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DCDB6EDA23C905C200F348EB /* MainMenu.xib */; };
 		E2E62BAC1781C33500F36275 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2E62BAB1781C33400F36275 /* Cocoa.framework */; };
 		E2E62BBA1781C37300F36275 /* MBTableGrid.m in Sources */ = {isa = PBXBuildFile; fileRef = C9412A3E0D8A061C00E9E614 /* MBTableGrid.m */; };
@@ -77,6 +83,12 @@
 		C9412D7B0D8B5AB900E9E614 /* MBTableGridCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBTableGridCell.h; sourceTree = SOURCE_ROOT; };
 		C9412D7C0D8B5AB900E9E614 /* MBTableGridCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBTableGridCell.m; sourceTree = SOURCE_ROOT; };
 		CA46E3611A09726A00C43B4B /* MBTableGridEditable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBTableGridEditable.h; sourceTree = SOURCE_ROOT; };
+		DC7EBF3F23D2157B00F75351 /* MBTableGridContentScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBTableGridContentScrollView.h; sourceTree = SOURCE_ROOT; };
+		DC7EBF4023D2157B00F75351 /* MBTableGridContentScrollView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBTableGridContentScrollView.m; sourceTree = SOURCE_ROOT; };
+		DC7EBF4323D217DC00F75351 /* MBTableGridVirtualString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBTableGridVirtualString.h; sourceTree = SOURCE_ROOT; };
+		DC7EBF4423D217DC00F75351 /* MBTableGridVirtualString.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBTableGridVirtualString.m; sourceTree = SOURCE_ROOT; };
+		DC7EBF4723D21AE800F75351 /* MBTableGridTextFinderClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBTableGridTextFinderClient.h; sourceTree = SOURCE_ROOT; };
+		DC7EBF4823D21AE800F75351 /* MBTableGridTextFinderClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBTableGridTextFinderClient.m; sourceTree = SOURCE_ROOT; };
 		DCDB6EDA23C905C200F348EB /* MainMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainMenu.xib; sourceTree = "<group>"; };
 		E2E62BAA1781C33400F36275 /* MBTableGrid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MBTableGrid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2E62BAB1781C33400F36275 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -201,6 +213,12 @@
 				C9412A3E0D8A061C00E9E614 /* MBTableGrid.m */,
 				C9412B200D8B2C5E00E9E614 /* MBTableGridContentView.h */,
 				C9412B210D8B2C5E00E9E614 /* MBTableGridContentView.m */,
+				DC7EBF3F23D2157B00F75351 /* MBTableGridContentScrollView.h */,
+				DC7EBF4023D2157B00F75351 /* MBTableGridContentScrollView.m */,
+				DC7EBF4323D217DC00F75351 /* MBTableGridVirtualString.h */,
+				DC7EBF4423D217DC00F75351 /* MBTableGridVirtualString.m */,
+				DC7EBF4723D21AE800F75351 /* MBTableGridTextFinderClient.h */,
+				DC7EBF4823D21AE800F75351 /* MBTableGridTextFinderClient.m */,
 				C6BF26881A4AC502008EB93F /* MBTableGridFooterView.h */,
 				C6BF26861A4AC4EE008EB93F /* MBTableGridFooterView.m */,
 				C9412B380D8B2F5400E9E614 /* MBTableGridHeaderView.h */,
@@ -226,11 +244,14 @@
 				173D292D1AA1779F009945FC /* MBFooterTextCell.h in Headers */,
 				E2E62BFB1781C53800F36275 /* MBTableGridCell.h in Headers */,
 				CA46E3621A09726A00C43B4B /* MBTableGridEditable.h in Headers */,
+				DC7EBF4123D2157B00F75351 /* MBTableGridContentScrollView.h in Headers */,
 				E2E62BFA1781C53800F36275 /* MBTableGridHeaderCell.h in Headers */,
+				DC7EBF4923D21AE800F75351 /* MBTableGridTextFinderClient.h in Headers */,
 				E2E62BF71781C53800F36275 /* MBTableGrid.h in Headers */,
 				E2E62BF81781C53800F36275 /* MBTableGridContentView.h in Headers */,
 				E2E62BF91781C53800F36275 /* MBTableGridHeaderView.h in Headers */,
 				C6BF26891A4AC502008EB93F /* MBTableGridFooterView.h in Headers */,
+				DC7EBF4523D217DC00F75351 /* MBTableGridVirtualString.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -339,8 +360,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				E2E62BBA1781C37300F36275 /* MBTableGrid.m in Sources */,
+				DC7EBF4A23D21AE800F75351 /* MBTableGridTextFinderClient.m in Sources */,
 				C6BF26871A4AC4EE008EB93F /* MBTableGridFooterView.m in Sources */,
+				DC7EBF4623D217DC00F75351 /* MBTableGridVirtualString.m in Sources */,
 				E2E62BBB1781C37600F36275 /* MBTableGridContentView.m in Sources */,
+				DC7EBF4223D2157B00F75351 /* MBTableGridContentScrollView.m in Sources */,
 				E2E62BBC1781C37800F36275 /* MBTableGridHeaderView.m in Sources */,
 				173D292E1AA1779F009945FC /* MBFooterTextCell.m in Sources */,
 				E2E62BBD1781C37B00F36275 /* MBTableGridHeaderCell.m in Sources */,

--- a/MBTableGridContentScrollView.h
+++ b/MBTableGridContentScrollView.h
@@ -1,0 +1,12 @@
+//
+//  MBTableGridContentScrollView.h
+//  MBTableGrid
+//
+//  Created by Evan Miller on 1/17/20.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface MBTableGridContentScrollView : NSScrollView
+
+@end

--- a/MBTableGridContentScrollView.m
+++ b/MBTableGridContentScrollView.m
@@ -1,0 +1,33 @@
+//
+//  MBTableGridContentScrollView.m
+//  MBTableGrid
+//
+//  Created by Evan Miller on 1/17/20.
+//
+
+#import "MBTableGridContentScrollView.h"
+
+@implementation MBTableGridContentScrollView
+
++ (void)huntDownAndHideSearchFieldMenuItemsInView:(NSView *)v {
+    if ([v isKindOfClass:[NSSearchField class]]) {
+        NSSearchField *searchField = (NSSearchField *)v;
+        for (int i=2; i<8; i++) // Cut out unsupported operations.
+            [searchField.searchMenuTemplate itemAtIndex:i].hidden = YES;
+
+        return;
+    }
+    for (NSView *subview in v.subviews){
+        [self huntDownAndHideSearchFieldMenuItemsInView:subview];
+    }
+}
+
+- (void)setFindBarVisible:(BOOL)findBarVisible {
+    [super setFindBarVisible:findBarVisible];
+    
+    if (findBarVisible) {
+        [[self class] huntDownAndHideSearchFieldMenuItemsInView:self.findBarView];
+    }
+}
+
+@end

--- a/MBTableGridTextFinderClient.h
+++ b/MBTableGridTextFinderClient.h
@@ -1,0 +1,18 @@
+//
+//  MBTableGridTextFinderClient.h
+//  MBTableGrid
+//
+//  Created by Evan Miller on 1/17/20.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@class MBTableGrid;
+
+@interface MBTableGridTextFinderClient : NSObject<NSTextFinderClient> {
+    MBTableGrid *_tableGrid;
+}
+
+- (id)initWithTableGrid:(MBTableGrid *)tableGrid;
+
+@end

--- a/MBTableGridTextFinderClient.m
+++ b/MBTableGridTextFinderClient.m
@@ -1,0 +1,208 @@
+//
+//  MBTableGridTextFinderClient.m
+//  MBTableGrid
+//
+//  Created by Evan Miller on 1/17/20.
+//
+
+#import "MBTableGridTextFinderClient.h"
+#import "MBTableGridVirtualString.h"
+#import "MBTableGrid.h"
+#import "MBTableGridContentView.h"
+
+@interface MBTableGrid ()
+- (void)scrollToArea:(NSRect)area animate:(BOOL)animate;
+@end
+
+@implementation MBTableGridTextFinderClient
+
+// Pros and cons of string vs stringAtIndex:effectiveRange:endsWithSearchBoundary
+// - the returned `string` can be subclassed - i.e. do a search without creating any substrings
+// - `string` can be cancelled inside of rangeOfString:options: (read a value and return NSNotFound)
+// - `stringAtIndex:` crashes with 10s of thousands of substrings - AppKit bug
+// - BUT `string` searches are on the main thread, whereas stringAtIndex: gets kicked off to worker threads
+// - So `string` looks faster and more stable overall - at the cost of pinning the UI on large tables. Sigh.
+#define _row(cellIndex, rows, cols) ((cellIndex) % (rows) + (cols-cols))
+#define _col(cellIndex, rows, cols) ((cellIndex) / (rows) + (cols-cols))
+#define _cell(rowIndex, columnIndex, rowCount, columCount) ((columnIndex) * (rowCount) + (rowIndex) + (columnCount-columnCount))
+
+- (id)initWithTableGrid:(MBTableGrid *)tableGrid {
+    if (self = [super init]) {
+        _tableGrid = tableGrid;
+    }
+    return self;
+}
+
+- (NSString *)string {
+    return [[MBTableGridVirtualString alloc] initWithTableGrid:_tableGrid];
+}
+
+- (NSRange)firstSelectedRange {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    NSUInteger rowIndex = 0, columnIndex = 0;
+
+    if (_tableGrid.selectedRowIndexes)
+        rowIndex = _tableGrid.selectedRowIndexes.firstIndex;
+
+    if (_tableGrid.selectedColumnIndexes)
+        columnIndex = _tableGrid.selectedColumnIndexes.firstIndex;
+        
+    NSUInteger cellIndex = _cell(rowIndex, columnIndex, rowCount, columnCount);
+
+    return NSMakeRange(cellIndex, 1);
+}
+
+- (NSArray<NSValue *> *)selectedRanges {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    
+    if (rowCount == 0 || columnCount == 0)
+        return @[];
+    
+    if (!_tableGrid.selectedRowIndexes && !_tableGrid.selectedColumnIndexes)
+        return @[];
+    
+    NSMutableArray<NSValue *> *ranges = [NSMutableArray array];
+    NSUInteger minRow = 0, maxRow = rowCount-1;
+    NSUInteger minCol = 0, maxCol = columnCount-1;
+    
+    if (_tableGrid.selectedColumnIndexes) {
+        minCol = _tableGrid.selectedColumnIndexes.firstIndex;
+        maxCol = _tableGrid.selectedColumnIndexes.lastIndex;
+    }
+
+    if (_tableGrid.selectedRowIndexes) {
+        minRow = _tableGrid.selectedRowIndexes.firstIndex;
+        maxRow = _tableGrid.selectedRowIndexes.lastIndex;
+    }
+    
+    for (NSUInteger j=minCol; j<=maxCol; j++) {
+        NSUInteger cellIndex = _cell(minRow, j, rowCount, columnCount);
+        NSRange range = NSMakeRange(cellIndex, (maxRow - minRow + 1));
+        [ranges addObject:[NSValue valueWithRange:range]];
+    }
+    
+    return ranges;
+}
+
+- (void)setSelectedRanges:(NSArray<NSValue *> *)selectedRanges {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    
+    if (selectedRanges.count) {
+        NSUInteger cellIndex = selectedRanges.firstObject.rangeValue.location;
+        NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
+        NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
+        
+        _tableGrid.selectedRowIndexes = [NSIndexSet indexSetWithIndex:rowIndex];
+        _tableGrid.selectedColumnIndexes = [NSIndexSet indexSetWithIndex:filteredIndex];
+    }
+}
+
+- (void)scrollRangeToVisible:(NSRange)range {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    NSUInteger cellIndex = range.location;
+    NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
+    NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
+        
+    [_tableGrid scrollToArea:[_tableGrid.contentView frameOfCellAtColumn:filteredIndex row:rowIndex] animate:NO];
+}
+
+- (NSView *)contentViewAtIndex:(NSUInteger)index effectiveCharacterRange:(NSRangePointer)outRange {
+    // One big fat view
+    outRange->location = 0;
+    outRange->length = _tableGrid.numberOfColumns * _tableGrid.numberOfRows;
+    return _tableGrid.contentView;
+}
+
+- (NSArray<NSValue *> *)rectsForCharacterRange:(NSRange)range {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    NSUInteger cellIndex = range.location;
+    NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
+    NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
+        
+    return @[ [NSValue valueWithRect:[_tableGrid.contentView frameOfCellAtColumn:filteredIndex row:rowIndex] ] ];
+}
+
+- (NSArray<NSValue *> *)visibleCharacterRanges {
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+
+    NSRect visibleRect = _tableGrid.contentView.visibleRect;
+    NSPoint topLeft = visibleRect.origin;
+    NSPoint bottomRight = NSMakePoint(CGRectGetMaxX(visibleRect), CGRectGetMaxY(visibleRect));
+    NSInteger minColumn = [_tableGrid.contentView columnAtPoint:topLeft];
+    NSInteger maxColumn = [_tableGrid.contentView columnAtPoint:bottomRight];
+    if (maxColumn == NSNotFound) {
+        maxColumn = _tableGrid.numberOfColumns-1;
+    }
+    NSInteger minRow = [_tableGrid.contentView rowAtPoint:topLeft];
+    NSInteger maxRow = [_tableGrid.contentView rowAtPoint:bottomRight];
+    if (maxRow == NSNotFound) {
+        maxRow = _tableGrid.numberOfRows-1;
+    }
+    NSMutableArray<NSValue *> *arrays_of_ranges = [NSMutableArray array];
+    for (NSInteger j=minColumn; j<=maxColumn; j++) {
+        NSInteger firstIndex = (j*rowCount + minRow);
+        NSInteger lastIndex = (j*rowCount + maxRow);
+        NSRange range = NSMakeRange(firstIndex, (lastIndex - firstIndex + 1));
+        [arrays_of_ranges addObject:[NSValue valueWithRange:range]];
+    }
+    return arrays_of_ranges;
+}
+
+- (void)drawCharactersInRange:(NSRange)range forContentView:(NSView *)view {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    NSUInteger cellIndex = range.location;
+    NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
+    NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
+    NSCell* cell = [_tableGrid.dataSource tableGrid:_tableGrid cellForColumn:filteredIndex row:rowIndex];
+    NSRect cellFrame = [_tableGrid.contentView frameOfCellAtColumn:filteredIndex row:rowIndex];
+    [cell drawInteriorWithFrame:cellFrame inView:view];
+}
+
+- (BOOL)shouldReplaceCharactersInRanges:(NSArray<NSValue *> *)ranges withStrings:(NSArray<NSString *> *)strings {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    for (NSValue *rangeValue in ranges) {
+        NSRange range = rangeValue.rangeValue;
+        NSUInteger cellIndex = range.location;
+        if (range.location == NSNotFound)
+            continue;
+        while (cellIndex < range.location + range.length) {
+            NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
+            NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
+            if (![_tableGrid.delegate tableGrid:_tableGrid shouldEditColumn:filteredIndex row:rowIndex])
+                return NO;
+
+            cellIndex++;
+        }
+    }
+    return YES;
+}
+
+- (void)replaceCharactersInRange:(NSRange)range withString:(NSString *)string {
+    NSUInteger columnCount = _tableGrid.numberOfColumns;
+    NSUInteger rowCount = _tableGrid.numberOfRows;
+    
+    NSUInteger cellIndex = range.location;
+    NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
+    NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
+    
+    [_tableGrid.dataSource tableGrid:_tableGrid setObjectValue:string forColumn:filteredIndex row:rowIndex];
+}
+
+- (BOOL)isEditable {
+    return [_tableGrid.dataSource respondsToSelector:@selector(tableGrid:setObjectValue:forColumn:row:)];
+}
+
+- (void)didReplaceCharacters {
+    // TODO store up replacements in a "Replace All" and blast them to the data source all at once
+    [_tableGrid reloadData];
+}
+
+
+@end

--- a/MBTableGridTextFinderClient.m
+++ b/MBTableGridTextFinderClient.m
@@ -11,6 +11,10 @@
 #import "MBTableGridContentView.h"
 
 @interface MBTableGrid ()
+- (NSCell *)_cellForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
+- (id)_objectValueForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
+- (void)_setObjectValue:(id)value forColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
+- (BOOL)_canEditCellAtColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 - (void)scrollToArea:(NSRect)area animate:(BOOL)animate;
 @end
 
@@ -159,7 +163,7 @@
     NSUInteger cellIndex = range.location;
     NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
     NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
-    NSCell* cell = [_tableGrid.dataSource tableGrid:_tableGrid cellForColumn:filteredIndex row:rowIndex];
+    NSCell* cell = [_tableGrid _cellForColumn:filteredIndex row:rowIndex];
     NSRect cellFrame = [_tableGrid.contentView frameOfCellAtColumn:filteredIndex row:rowIndex];
     [cell drawInteriorWithFrame:cellFrame inView:view];
 }
@@ -175,7 +179,7 @@
         while (cellIndex < range.location + range.length) {
             NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
             NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
-            if (![_tableGrid.delegate tableGrid:_tableGrid shouldEditColumn:filteredIndex row:rowIndex])
+            if (![_tableGrid _canEditCellAtColumn:filteredIndex row:rowIndex])
                 return NO;
 
             cellIndex++;
@@ -192,7 +196,7 @@
     NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
     NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);
     
-    [_tableGrid.dataSource tableGrid:_tableGrid setObjectValue:string forColumn:filteredIndex row:rowIndex];
+    [_tableGrid _setObjectValue:string forColumn:filteredIndex row:rowIndex];
 }
 
 - (BOOL)isEditable {

--- a/MBTableGridVirtualString.h
+++ b/MBTableGridVirtualString.h
@@ -1,0 +1,18 @@
+//
+//  MBTableGridVirtualString.h
+//  MBTableGrid
+//
+//  Created by Evan Miller on 1/17/20.
+//
+
+#import <Foundation/Foundation.h>
+
+@class MBTableGrid;
+
+@interface MBTableGridVirtualString : NSString {
+    MBTableGrid *_tableGrid;
+}
+
+- (id)initWithTableGrid:(MBTableGrid *)tableGrid;
+
+@end

--- a/MBTableGridVirtualString.m
+++ b/MBTableGridVirtualString.m
@@ -1,0 +1,73 @@
+//
+//  MBTableGridVirtualString.m
+//  MBTableGrid
+//
+//  Created by Evan Miller on 1/17/20.
+//
+
+#import "MBTableGridVirtualString.h"
+#import "MBTableGrid.h"
+
+#define _row(cellIndex, rows, cols) ((cellIndex) % (rows) + (cols-cols))
+#define _col(cellIndex, rows, cols) ((cellIndex) / (rows) + (cols-cols))
+
+@interface MBTableGrid ()
+
+@property (nonatomic, readonly) BOOL _shouldAbortFindOperation;
+
+@end
+
+@implementation MBTableGridVirtualString
+
+/* This is a virtual string that treats cells as individual "characters" that can be searched
+ * by an instance of NSTextFinder. For details see:
+ *
+ * https://github.com/pixelspark/mbtablegrid/issues/31
+ *
+ * Searches in column-first order.
+ */
+
+- (id)initWithTableGrid:(MBTableGrid *)tableGrid {
+    if (self = [super init]) {
+        _tableGrid = tableGrid;
+    }
+    return self;
+}
+
+- (NSUInteger)length {
+    return _tableGrid.numberOfRows * _tableGrid.numberOfColumns;
+}
+
+- (NSRange)rangeOfString:(NSString *)searchString options:(NSStringCompareOptions)mask range:(NSRange)rangeOfReceiverToSearch {
+    NSUInteger cellIndex = rangeOfReceiverToSearch.location;
+    
+    NSInteger rowCount = _tableGrid.numberOfRows;
+    NSInteger columnCount = _tableGrid.numberOfColumns;
+    
+    while (cellIndex < rangeOfReceiverToSearch.location + rangeOfReceiverToSearch.length) {
+        NSRange result = NSMakeRange(NSNotFound, 0);
+        NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
+        NSUInteger columnIndex = _col(cellIndex, rowCount, columnCount);
+        
+        @autoreleasepool {
+            NSString *value = [_tableGrid.dataSource tableGrid:_tableGrid objectValueForColumn:columnIndex row:rowIndex];
+            if (value) {
+                result = [value rangeOfString:searchString options:mask];
+            }
+        }
+        
+        if (result.location != NSNotFound) {
+            return NSMakeRange(cellIndex, 1);
+        }
+        
+        /* Checking whether to abort is expensive (requires access to main thread),
+         * so don't do it too often */
+        if ((cellIndex % 1000) == 0 && _tableGrid._shouldAbortFindOperation)
+            break;
+        
+        cellIndex++;
+    }
+    return NSMakeRange(NSNotFound, 0);
+}
+
+@end

--- a/MBTableGridVirtualString.m
+++ b/MBTableGridVirtualString.m
@@ -11,9 +11,11 @@
 #define _row(cellIndex, rows, cols) ((cellIndex) % (rows) + (cols-cols))
 #define _col(cellIndex, rows, cols) ((cellIndex) / (rows) + (cols-cols))
 
-@interface MBTableGrid ()
+@interface MBTableGrid (Private)
 
 @property (nonatomic, readonly) BOOL _shouldAbortFindOperation;
+
+- (id)_objectValueForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 
 @end
 
@@ -50,7 +52,7 @@
         NSUInteger columnIndex = _col(cellIndex, rowCount, columnCount);
         
         @autoreleasepool {
-            NSString *value = [_tableGrid.dataSource tableGrid:_tableGrid objectValueForColumn:columnIndex row:rowIndex];
+            NSString *value = [_tableGrid _objectValueForColumn:columnIndex row:rowIndex];
             if (value) {
                 result = [value rangeOfString:searchString options:mask];
             }

--- a/MainMenu.xib
+++ b/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -173,28 +173,28 @@
                                     <items>
                                         <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
                                             <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="cD7-Qs-BN4"/>
+                                                <action selector="performTextFinderAction:" target="-1" id="Qv5-UK-SIH"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                             <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="WD3-Gg-5AJ"/>
+                                                <action selector="performTextFinderAction:" target="-1" id="0bo-BD-UNd"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
                                             <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="NDo-RZ-v9R"/>
+                                                <action selector="performTextFinderAction:" target="-1" id="Ovg-ig-Yyq"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
                                             <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="HOh-sY-3ay"/>
+                                                <action selector="performTextFinderAction:" target="-1" id="a63-6L-E2t"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
                                             <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="U76-nv-p5D"/>
+                                                <action selector="performTextFinderAction:" target="-1" id="0co-J5-Je0"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
@@ -675,14 +675,14 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="" animationBehavior="default" id="v2q-IV-t0S">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="213" y="227" width="480" height="270"/>
+            <rect key="contentRect" x="213" y="227" width="637" height="404"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1129"/>
             <view key="contentView" id="Hs4-fn-RAG">
-                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                <rect key="frame" x="0.0" y="0.0" width="637" height="404"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BaF-l2-x7N" customClass="MBTableGrid">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <rect key="frame" x="0.0" y="0.0" width="637" height="404"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <connections>
                             <outlet property="dataSource" destination="Cmj-KX-obJ" id="14y-Nz-LEb"/>
@@ -691,7 +691,7 @@
                     </customView>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="-12" y="393"/>
+            <point key="canvasLocation" x="66.5" y="460"/>
         </window>
         <customObject id="Cmj-KX-obJ" customClass="MBTableGridController">
             <connections>


### PR DESCRIPTION
Implement a Find / Replace bar via the `NSTextFinder` mechanisms. I found AppKit to be buggy when searching very large strings (or arrays of strings), so use a "virtual" string class where each cell represents one "character".

Matching is performed by retrieving the text value from `tableGrid:objectValueForColumn:row:`. The "character" is matched if the search string is present in the cell's string representation. Replacing is done using `tableGrid:setObjectValue:forColumn:row:`. Note that Find/Replace therefore only works on entire cells. That is, you can't replace a substring within a cell.

`NSTextFinder` kicks off background threads for searching. We prematurely terminate these threads by periodically checking to see whether the Find bar is still visible. If it's not visible, either because the user pressed Done or the table grid was hidden, the search is stopped.

A new `findBarVisible` property has been added `MBTableGrid`, which can call up the find bar, or hide it away. It simply passes the messages onto the scroll view (which is the Find bar's container).

Subclassing `NSScrollView` was necessary in order to prevent certain Find options from appearing. When the "Starts With" or "Whole Word" options are checked in the Find bar's menu, `NSTextFinder` fires up the internal regular expression engine, which is incompatible with the virtual string strategy described above. So we hide those options before displaying the Find bar by manipulating the `searchMenuTemplate` of the associated `NSSearchField`.

Searching happens in column-first order, which is what I needed for my own application. Row-first searching could be added later. Inquire within.

For large grids, we'll likely need some kind of bulk-replacement mechanism, e.g. a new `setObjectValue:` delegate method that takes an `NSIndexSet` (or two). This should be considered in conjunction with a revised `deleteBackward:` action, which currently loops over all of the selected cells, and is very slow.

Fixes #31