### PR TITLE
Show/Hide auxiliary views

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -151,6 +151,10 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
 @property (nonatomic, readonly) MBTableGridFooterView* columnFooterView;
 @property (nonatomic, readonly) MBTableGridHeaderView* rowHeaderView;
 
+@property (getter=isColumnHeaderVisible, nonatomic, assign) BOOL columnHeaderVisible;
+@property (getter=isColumnFooterVisible, nonatomic, assign) BOOL columnFooterVisible;
+@property (getter=isRowHeaderVisible, nonatomic, assign) BOOL rowHeaderVisible;
+
 - (void)setSelectedRowIndexes:(NSIndexSet *)anIndexSet notify:(BOOL)notify;
 - (void)setSelectedColumnIndexes:(NSIndexSet *)anIndexSet notify:(BOOL)notify;
 

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -37,6 +37,10 @@ NSString *MBTableGridDidMoveColumnsNotification         = @"MBTableGridDidMoveCo
 NSString *MBTableGridDidMoveRowsNotification            = @"MBTableGridDidMoveRowsNotification";
 CGFloat MBTableHeaderMinimumColumnWidth = 60.0f;
 
+#define MBTableGridColumnHeaderHeight 24.0
+#define MBTableGridColumnFooterHeight 24.0
+#define MBTableGridRowHeaderWidth 40.0
+
 #pragma mark -
 #pragma mark Drag Types
 NSString *MBTableGridColumnDataType = @"mbtablegrid.pasteboard.column";
@@ -1348,7 +1352,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 - (NSRect)rectOfColumn:(NSUInteger)columnIndex {
 	NSRect rect = [self convertRect:[contentView rectOfColumn:columnIndex] fromView:contentView];
 	rect.origin.y = 0;
-	rect.size.height += MBTableGridColumnHeaderHeight;
+	rect.size.height += columnHeaderScrollView.frame.size.height;
 	if (rect.size.height > self.frame.size.height) {
 		rect.size.height = self.frame.size.height;
 
@@ -1365,7 +1369,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 - (NSRect)rectOfRow:(NSUInteger)rowIndex {
 	NSRect rect = [self convertRect:[contentView rectOfRow:rowIndex] fromView:contentView];
 	rect.origin.x = 0;
-	rect.size.width += MBTableGridRowHeaderWidth;
+	rect.size.width += rowHeaderScrollView.frame.size.width;
 
 	return rect;
 }
@@ -1400,12 +1404,18 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (NSRect)headerRectOfCorner {
-	NSRect rect = NSMakeRect(0, 0, MBTableGridRowHeaderWidth, MBTableGridColumnHeaderHeight);
+    NSRect rect = NSMakeRect(NSMinX(rowHeaderScrollView.frame),
+                             NSMinY(columnHeaderScrollView.frame),
+                             NSWidth(rowHeaderScrollView.frame),
+                             NSHeight(columnHeaderScrollView.frame));
 	return rect;
 }
 
 - (NSRect)footerRectOfCorner {
-	NSRect rect = NSMakeRect(0, self.frame.size.height - MBTableGridColumnFooterHeight, MBTableGridRowHeaderWidth, MBTableGridColumnFooterHeight);
+    NSRect rect = NSMakeRect(NSMinX(rowHeaderScrollView.frame),
+                             NSMinY(columnFooterScrollView.frame),
+                             NSWidth(rowHeaderScrollView.frame),
+                             NSHeight(columnFooterScrollView.frame));
 	return rect;
 }
 
@@ -1437,6 +1447,51 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (MBTableGridContentView *)contentView {
 	return contentView;
+}
+
+- (BOOL)isColumnHeaderVisible {
+    return columnHeaderScrollView.frame.size.height > 0.0;
+}
+
+- (void)setColumnHeaderVisible:(BOOL)isVisible {
+    [columnHeaderScrollView removeConstraints:columnHeaderScrollView.constraints];
+    [NSLayoutConstraint constraintWithItem:columnHeaderScrollView
+                                 attribute:NSLayoutAttributeHeight
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:nil
+                                 attribute:NSLayoutAttributeNotAnAttribute
+                                multiplier:0.0
+                                  constant:isVisible ? MBTableGridColumnHeaderHeight : 0.0].active = YES;
+}
+
+- (BOOL)isColumnFooterVisible {
+    return columnFooterScrollView.frame.size.height > 0.0;
+}
+
+- (void)setColumnFooterVisible:(BOOL)isVisible {
+    [columnFooterScrollView removeConstraints:columnFooterScrollView.constraints];
+    [NSLayoutConstraint constraintWithItem:columnFooterScrollView
+                                 attribute:NSLayoutAttributeHeight
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:nil
+                                 attribute:NSLayoutAttributeNotAnAttribute
+                                multiplier:0.0
+                                  constant:isVisible ? MBTableGridColumnFooterHeight : 0.0].active = YES;
+}
+
+- (BOOL)isRowHeaderVisible {
+    return rowHeaderScrollView.frame.size.width > 0.0;
+}
+
+- (void)setRowHeaderVisible:(BOOL)isVisible {
+    [rowHeaderScrollView removeConstraints:rowHeaderScrollView.constraints];
+    [NSLayoutConstraint constraintWithItem:rowHeaderScrollView
+                                 attribute:NSLayoutAttributeWidth
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:nil
+                                 attribute:NSLayoutAttributeNotAnAttribute
+                                multiplier:0.0
+                                  constant:isVisible ? MBTableGridRowHeaderWidth : 0.0].active = YES;
 }
 
 #pragma mark - Overridden Property Accessors

--- a/MBTableGridContentView.h
+++ b/MBTableGridContentView.h
@@ -25,11 +25,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-#define MBTableGridColumnHeaderHeight 24.0
-#define MBTableGridColumnFooterHeight 24.0
-#define MBTableGridColumnHeaderWidth 60
-#define MBTableGridRowHeaderWidth 40.0
-
 typedef NS_ENUM(NSUInteger, MBTableGridTrackingPart)
 {
     MBTableGridTrackingPartNone = 0,

--- a/MBTableGridController.m
+++ b/MBTableGridController.m
@@ -103,6 +103,20 @@ NSString * const PasteboardTypeColumnClass = @"pasteboardTypeColumnClass";
     return randomString;
 }
 
+#pragma mark Actions
+
+- (IBAction)toggleColumnHeaderVisible:(NSButton *)sender {
+    tableGrid.columnHeaderVisible = !tableGrid.isColumnHeaderVisible;
+}
+
+- (IBAction)toggleRowHeaderVisible:(NSButton *)sender {
+    tableGrid.rowHeaderVisible = !tableGrid.isRowHeaderVisible;
+}
+
+- (IBAction)toggleColumnFooterVisible:(NSButton *)sender {
+    tableGrid.columnFooterVisible = !tableGrid.isColumnFooterVisible;
+}
+
 #pragma mark -
 #pragma mark Protocol Methods
 

--- a/MBTableGridFooterView.m
+++ b/MBTableGridFooterView.m
@@ -112,7 +112,7 @@
 - (NSRect)footerRectOfColumn:(NSUInteger)columnIndex
 {
 	NSRect rect = [[self.tableGrid _contentView] rectOfColumn:columnIndex];
-	rect.size.height = MBTableGridColumnHeaderHeight;
+	rect.size.height = NSHeight(self.bounds);
 	
 	return rect;
 }

--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -504,7 +504,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 - (NSRect)headerRectOfColumn:(NSUInteger)columnIndex
 {
 	NSRect rect = [self.tableGrid._contentView rectOfColumn:columnIndex];
-	rect.size.height = MBTableGridColumnHeaderHeight;
+	rect.size.height = NSHeight(self.bounds);
 	
 	return rect;
 }
@@ -512,7 +512,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 - (NSRect)headerRectOfRow:(NSUInteger)rowIndex
 {
 	NSRect rect = [self.tableGrid._contentView rectOfRow:rowIndex];
-	rect.size.width = MBTableGridRowHeaderWidth;
+	rect.size.width = NSWidth(self.bounds);
 	
 	return rect;
 }

--- a/MainMenu.xib
+++ b/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -675,23 +675,56 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="" animationBehavior="default" id="v2q-IV-t0S">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="213" y="227" width="480" height="270"/>
+            <rect key="contentRect" x="213" y="227" width="498" height="270"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1129"/>
             <view key="contentView" id="Hs4-fn-RAG">
-                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                <rect key="frame" x="0.0" y="0.0" width="498" height="270"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BaF-l2-x7N" customClass="MBTableGrid">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <rect key="frame" x="0.0" y="32" width="498" height="238"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <connections>
                             <outlet property="dataSource" destination="Cmj-KX-obJ" id="14y-Nz-LEb"/>
                             <outlet property="delegate" destination="Cmj-KX-obJ" id="VlG-Mn-qdl"/>
                         </connections>
                     </customView>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r9J-vK-SVT">
+                        <rect key="frame" x="3" y="-1" width="179" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <buttonCell key="cell" type="push" title="Toggle Column Header" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="cE8-mf-gAC">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="toggleColumnHeaderVisible:" target="Cmj-KX-obJ" id="FAq-It-xlm"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3A8-nU-0hC">
+                        <rect key="frame" x="174" y="-1" width="158" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <buttonCell key="cell" type="push" title="Toggle Row Header" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iiq-YU-4D7">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="toggleRowHeaderVisible:" target="Cmj-KX-obJ" id="gIP-Wq-kRx"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tdy-eS-MBW">
+                        <rect key="frame" x="323" y="-1" width="174" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                        <buttonCell key="cell" type="push" title="Toggle Column Footer" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="0xo-17-mo4">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="toggleColumnFooterVisible:" target="Cmj-KX-obJ" id="hhR-5M-2ij"/>
+                        </connections>
+                    </button>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="-12" y="393"/>
+            <point key="canvasLocation" x="-3" y="393"/>
         </window>
         <customObject id="Cmj-KX-obJ" customClass="MBTableGridController">
             <connections>


### PR DESCRIPTION
New read/write properties: `columnHeaderVisible`, `rowHeaderVisible`, `columnFooterVisible`

Uses auto layout to set the width or height of the auxiliary view to 0, so things should "just work". Other internal logic has been updated to get rid of constants and rely on run-time widths or heights, which now could be zero. Also slightly better support for an RTL configuration
(i.e. removing left-hand assumptions from `headerRectOfCorner` and `footerRectOfCorner`), but proper RTL would require laying out the columns from right to left, and maybe reworking the keyboard navigation.

Added buttons to the test program to demonstrate the show/hide functionality.

Fixes #22