### PR TITLE
New delegate methods before displaying header menus

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -1215,4 +1215,39 @@ cells. A cell can individually override this behavior. */
 
 - (void)tableGrid:(MBTableGrid*)aTableGrid footerCellClicked:(NSCell*)cell forColumn:(NSUInteger)columnIndex withEvent:(NSEvent*)theEvent;
 
+#pragma mark Displaying Menus
+
+/**
+ * @brief   Informs the delegate that the column header's contextual menu is about to be displayed.
+ *          The menu items can then be customized for the particular column.
+ *          (The column header menu can be set via the \c menu property of the table grid's \c columnHeaderView.)
+ *
+ *  @param  aTableGrid      The table grid object that will display the menu
+ *
+ *  @param  menu                    The menu about to be displayed
+ *
+ *  @param  columnIndex     The column that was clicked (right-clicked or Control-clicked)
+ *
+ *  @see    tableGrid:willDisplayHeaderMenu:forRow:
+ */
+
+- (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayHeaderMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex;
+
+/**
+ * @brief   Informs the delegate that the row header's contextual menu is about to be displayed.
+ *          The menu items can then be customized for the particular row.
+ *          (The row header menu can be set via the \c menu property of the table grid's \c rowHeaderView.)
+ *
+ *  @param  aTableGrid      The table grid object that will display the menu
+ *
+ *  @param  menu                    The menu about to be displayed
+ *
+ *  @param  rowIndex            The row that was clicked (right-clicked or Control-clicked)
+ *
+ *  @see    tableGrid:willDisplayHeaderMenu:forColumn:
+ */
+
+- (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayHeaderMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex;
+
+
 @end

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1774,3 +1774,17 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 @end
+
+@implementation MBTableGrid (HeaderMenus)
+
+- (void)_willDisplayHeaderMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex {
+    if ([self.delegate respondsToSelector:@selector(tableGrid:willDisplayHeaderMenu:forColumn:)])
+        [self.delegate tableGrid:self willDisplayHeaderMenu:menu forColumn:columnIndex];
+}
+
+- (void)_willDisplayHeaderMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex {
+    if ([self.delegate respondsToSelector:@selector(tableGrid:willDisplayHeaderMenu:forRow:)])
+        [self.delegate tableGrid:self willDisplayHeaderMenu:menu forRow:rowIndex];
+}
+
+@end

--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -39,6 +39,8 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 - (MBTableGridContentView *)_contentView;
 - (void)_dragColumnsWithEvent:(NSEvent *)theEvent;
 - (void)_dragRowsWithEvent:(NSEvent *)theEvent;
+- (void)_willDisplayHeaderMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex;
+- (void)_willDisplayHeaderMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex;
 @end
 
 @implementation MBTableGridHeaderView
@@ -240,6 +242,20 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 	return YES;
 }
 
+- (NSMenu *)menuForEvent:(NSEvent *)theEvent {
+    NSPoint event_location = theEvent.locationInWindow;
+    NSPoint local_point = [self convertPoint:event_location fromView:nil];
+    if (self.orientation == MBTableHeaderHorizontalOrientation) {
+        NSInteger column = [self.tableGrid columnAtPoint:[self convertPoint:local_point toView:self.tableGrid]];
+        [self.tableGrid _willDisplayHeaderMenu:self.menu forColumn:column];
+    } else {
+        NSInteger row = [self.tableGrid rowAtPoint:[self convertPoint:local_point toView:self.tableGrid]];
+        [self.tableGrid _willDisplayHeaderMenu:self.menu forRow:row];
+    }
+
+    return self.menu;
+}
+
 - (void)_mouseDown:(NSEvent *)theEvent right:(BOOL)rightMouse
 {
 	// Get the location of the click
@@ -326,10 +342,6 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 
 - (void) rightMouseDown:(NSEvent *)theEvent {
 	[self _mouseDown:theEvent right:TRUE];
-}
-
-- (void) rightMouseUp:(NSEvent *)theEvent {
-	[NSMenu popUpContextMenu:self.menu withEvent:theEvent forView:self];
 }
 
 - (void)mouseDragged:(NSEvent *)theEvent


### PR DESCRIPTION
Intercept `menuForEvent:` so that the delegate can know which row or column was clicked (which might differ from the current selection), and modify the menu accordingly. The new delegate methods are:

```
- (void)tableGrid:(*) willDisplayHeaderMenu:(NSMenu *) forColumn:(NSUInteger);
- (void)tableGrid:(*) willDisplayHeaderMenu:(NSMenu *) forRow:(NSUInteger);
```

Fixes #30