### PR TITLE
New delegate method for double-clicking a row

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -1091,12 +1091,24 @@ cells. A cell can individually override this behavior. */
  *
  * @param		aTableGrid		The table grid object informing the delegate
  *								about the double-click event
- * @param		columnIndex		The selected column in \c aTableGrid.
+ * @param		columnIndex		The double-clicked column in \c aTableGrid.
  *
  *
- * @see			tableGrid:willSelectColumnsAtIndexPath:
+ * @see			tableGrid:didDoubleClickRow:
  */
 - (void)tableGrid:(MBTableGrid *)aTableGrid didDoubleClickColumn:(NSUInteger)columnIndex;
+
+/**
+ * @brief        Tells the delegate that the specified row header was double-clicked
+ *
+ * @param        aTableGrid        The table grid object informing the delegate
+ *                                about the double-click event
+ * @param        columnIndex        The double-clicked row in \c aTableGrid.
+ *
+ *
+ * @see            tableGrid:didDoubleClickColumn:
+ */
+- (void)tableGrid:(MBTableGrid *)aTableGrid didDoubleClickRow:(NSUInteger)rowIndex;
 
 
 /**

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1633,6 +1633,20 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 @end
 
+@implementation MBTableGrid (DoubleClick)
+
+- (void)_didDoubleClickColumn:(NSUInteger)columnIndex {
+    if ([self.delegate respondsToSelector:@selector(tableGrid:didDoubleClickColumn:)])
+        [self.delegate tableGrid:self didDoubleClickColumn:columnIndex];
+}
+
+- (void)_didDoubleClickRow:(NSUInteger)rowIndex {
+    if ([self.delegate respondsToSelector:@selector(tableGrid:didDoubleClickRow:)])
+        [self.delegate tableGrid:self didDoubleClickRow:rowIndex];
+}
+
+@end
+
 @implementation MBTableGrid (PrivateAccessors)
 
 - (MBTableGridContentView *)_contentView {

--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -39,6 +39,8 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 - (MBTableGridContentView *)_contentView;
 - (void)_dragColumnsWithEvent:(NSEvent *)theEvent;
 - (void)_dragRowsWithEvent:(NSEvent *)theEvent;
+- (void)_didDoubleClickColumn:(NSUInteger)columnIndex;
+- (void)_didDoubleClickRow:(NSUInteger)rowIndex;
 @end
 
 @implementation MBTableGridHeaderView
@@ -249,8 +251,11 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 	NSInteger row = [self.tableGrid rowAtPoint:[self convertPoint:loc toView:self.tableGrid]];
 
 	if([theEvent clickCount] == 2 && !rightMouse) {
-        if ([self.tableGrid.delegate respondsToSelector:@selector(tableGrid:didDoubleClickColumn:)])
-            [self.tableGrid.delegate tableGrid:self.tableGrid didDoubleClickColumn:column];
+        if (self.orientation == MBTableHeaderHorizontalOrientation) {
+            [self.tableGrid _didDoubleClickColumn:column];
+        } else {
+            [self.tableGrid _didDoubleClickRow:row];
+        }
 	}
 	else {
 		if (canResize) {


### PR DESCRIPTION
Previously `tableGrid:didDoubleClickColumn:` was fired for the row
header also. Add a new delegate method to handle row-header
double-clicks:

```
- (void)tableGrid:(*) didDoubleClickRow:(NSUInteger)row;
```

Fixes #25