### PR TITLE
Keyboard navigation improvements

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -135,7 +135,6 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
 	
 	/* Behavior */
 	BOOL allowsMultipleSelection;
-	BOOL shouldOverrideModifiers;
 	
 	/* Sticky Edges (for Shift+Arrow expansions) */
 	MBHorizontalEdge stickyColumnEdge;


### PR DESCRIPTION
* Remove outdated `shouldOverrideModifiers` stuff

* `moveLeft:` and `moveRight:` no longer wrap around. Instead...

* Implement the following NSResponder actions:

    `moveToBeginningOfDocument:`  (Command-Up)
    `moveToBeginningOfDocumentAndModifySelection:` (Command-Shift-Up)
    `moveToEndOfDocument:`  (Command-Down)
    `moveToEndOfDocumentAndModifySelection:` (Command-Shift-Down)
    `moveToBeginningOfLine:`  (Command-Left)
    `moveToBeginningOfLineAndModifySelection:` (Command-Shift-Left)
    `moveToEndOfLine:`  (Command-Right)
    `moveToEndOfLineAndModifySelection:` (Command-Shift-Right)

The new behavior conforms closely to both Excel and Numbers, in particular with regard to the sticky edges.