### PR TITLE
Disable inactionable items in the Edit menu

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -515,6 +515,22 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 #pragma mark NSResponder Event Handlers
 
+- (BOOL)respondsToSelector:(SEL)aSelector {
+    if (aSelector == @selector(paste:)) {
+        return ([self.delegate respondsToSelector:@selector(tableGrid:pasteCellsAtColumns:rows:)]);
+    }
+    if (aSelector == @selector(copy:)) {
+        return (self.selectedRowIndexes.count > 0 && self.selectedColumnIndexes.count > 0 &&
+                [self.delegate respondsToSelector:@selector(tableGrid:copyCellsAtColumns:rows:)]);
+    }
+    if (aSelector == @selector(delete:) || aSelector == @selector(deleteBackward:)) {
+        return (self.selectedRowIndexes.count > 0 && self.selectedColumnIndexes.count > 0 &&
+                ([self.dataSource respondsToSelector:@selector(tableGrid:setObjectValue:forColumn:row:)] ||
+                 [self.dataSource respondsToSelector:@selector(tableGrid:setObjectValue:forColumns:rows:)]));
+    }
+    return [super respondsToSelector:aSelector];
+}
+
 - (void)copy:(id)sender {
 	
 	NSIndexSet *selectedColumns = [self selectedColumnIndexes];
@@ -1012,10 +1028,16 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	self.selectedRowIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, _numberOfRows)];
 }
 
+// Interpreted by interpretKeyEvents:
 - (void)deleteBackward:(id)sender {
 	// Clear the contents of every selected cell
     [self _setObjectValue:nil forColumns:self.selectedColumnIndexes rows:self.selectedRowIndexes];
 	[self reloadData];
+}
+
+// From the Edit menu
+- (void)delete:(id)sender {
+    [self deleteBackward:sender];
 }
 
 - (void)insertText:(id)aString {

--- a/MainMenu.xib
+++ b/MainMenu.xib
@@ -156,9 +156,11 @@
                                 </connections>
                             </menuItem>
                             <menuItem title="Delete" id="pa3-QI-u2k">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <string key="keyEquivalent" base64-UTF8="YES">
+CA
+</string>
                                 <connections>
-                                    <action selector="delete:" target="-1" id="0Mk-Ml-PaM"/>
+                                    <action selector="delete:" target="-1" id="kGx-Vi-DyP"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">


### PR DESCRIPTION
Copy, Paste, and Delete should only be active if the table grid can do something meaningful with them (i.e. the delegate or data source responds to the appropriate message).