### PR TITLE
New widthForColumn: data source method

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -692,7 +692,7 @@ cells. A cell can individually override this behavior. */
 @optional
 
 /**
- * @brief		Sets the column width for the given column.
+ * @brief		Sets the column width (in points) for the given column.
  *
  * @param		aTableGrid		The table grid that sent the message.
  * @param		columnIndex		A column in \c aTableGrid.
@@ -700,6 +700,18 @@ cells. A cell can individually override this behavior. */
   * @see			tableGrid:widthForColumn:
  */
 - (void) tableGrid:(MBTableGrid *)aTableGrid setWidth:(float)width forColumn:(NSUInteger)columnIndex;
+
+@optional
+
+/**
+ * @brief        Returns the column width (in points) for the given column.
+ *
+ * @param        aTableGrid        The table grid that sent the message.
+ * @param        columnIndex        A column in \c aTableGrid.
+ *
+ * @see          tableGrid:setWidth:forColumn:
+ */
+- (float) tableGrid:(MBTableGrid *)aTableGrid widthForColumn:(NSUInteger)columnIndex;
 
 /**
  * @}

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1765,12 +1765,24 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (CGFloat)_widthForColumn:(NSUInteger)columnIndex {
-    if (columnIndex < _numberOfColumns) {
-        if (_columnWidths[@(columnIndex)])
-            return _columnWidths[@(columnIndex)].doubleValue;
-        return [self _minimumWidthForColumn:columnIndex];
+    if (columnIndex >= _numberOfColumns)
+        return 0.0;
+    
+    CGFloat width = 0.0;
+    CGFloat min_width = [self _minimumWidthForColumn:columnIndex];
+    
+    if ([self.dataSource respondsToSelector:@selector(tableGrid:widthForColumn:)]) {
+        width = [self.dataSource tableGrid:self widthForColumn:columnIndex];
+        if (width > min_width) {
+            _columnWidths[@(columnIndex)] = @(width);
+        }
     }
-    return 0.0;
+    
+    if (_columnWidths[@(columnIndex)]) {
+        return _columnWidths[@(columnIndex)].doubleValue;
+    }
+
+    return min_width;
 }
 
 - (void)_setWidth:(CGFloat)width forColumn:(NSUInteger)columnIndex

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -734,15 +734,12 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 			CGFloat width = [self.tableGrid _widthForColumn:columnIndex];
 			
 			rect = NSMakeRect(0, 0, width, self.frame.size.height);
-			//rect.origin.x += 60.0 * columnIndex;
-			
-			NSUInteger i = 0;
-			while(i < columnIndex) {
-				CGFloat headerWidth = [self.tableGrid _widthForColumn:i];
-				rect.origin.x += headerWidth;
-				i++;
-			}
-		
+            
+            if (columnIndex > 0) {
+                NSRect previousRect = [self rectOfColumn:columnIndex-1];
+                rect.origin.x = previousRect.origin.x + previousRect.size.width;
+            }
+
 			self.tableGrid.columnRects[@(columnIndex)] = [NSValue valueWithRect:rect];
 
 		}


### PR DESCRIPTION
New method:

```
- (float) tableGrid:(MBTableGrid *)aTableGrid widthForColumn:(NSUInteger)columnIndex;
```

...should return the desired width (in points) of the given column. This allows applications to independently manage their column widths, with the results mirrored in the autosaved `_columnWidths` dictionary.

Using `float` to match the other APIs, but these should really be doubles.

Fixes #28