### PR TITLE
Color fixes

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1942,6 +1942,20 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	return stickyRowEdge;
 }
 
+- (BOOL)_containsFirstResponder {
+    NSResponder *firstResponder = self.window.firstResponder;
+    return self.window.isKeyWindow && [firstResponder isKindOfClass:NSView.class] && [(NSView *)firstResponder isDescendantOf:self];
+}
+
+- (NSColor *)_selectionColor {
+    NSColor *color = NSColor.alternateSelectedControlColor;
+    // If the view is not the first responder, then use a gray selection color
+    if (!self._containsFirstResponder)
+        return [color colorUsingColorSpace:NSColorSpace.genericGrayColorSpace];
+    
+    return color;
+}
+
 @end
 
 @implementation MBTableGrid (DragAndDrop)

--- a/MBTableGridHeaderCell.m
+++ b/MBTableGridHeaderCell.m
@@ -24,6 +24,8 @@
  */
 
 #import "MBTableGridHeaderCell.h"
+#import "MBTableGridHeaderView.h"
+#import "MBTableGrid.h"
 
 extern CGFloat MBTableHeaderSortIndicatorWidth;
 extern CGFloat MBTableHeaderSortIndicatorMargin;
@@ -32,6 +34,10 @@ extern CGFloat MBTableHeaderSortIndicatorMargin;
 
 @interface MBTableGridHeaderCell ()
 
+@end
+
+@interface MBTableGrid (Private)
+- (NSColor *)_selectionColor;
 @end
 
 #pragma mark -
@@ -71,7 +77,7 @@ extern CGFloat MBTableHeaderSortIndicatorMargin;
     return indicatorRect;
 }
 
-- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+- (void)drawWithFrame:(NSRect)cellFrame inView:(MBTableGridHeaderView *)controlView
 {
 	NSRect cellFrameRect = cellFrame;
 	
@@ -114,7 +120,7 @@ extern CGFloat MBTableHeaderSortIndicatorMargin;
 		}
 		NSBezierPath* path = [NSBezierPath bezierPathWithRoundedRect:fillRect xRadius:4.0 yRadius:4.0];
 
-		NSColor *overlayColor = [NSColor.alternateSelectedControlColor colorWithAlphaComponent:0.26];
+        NSColor *overlayColor = [controlView.tableGrid._selectionColor colorWithAlphaComponent:0.26];
 		[overlayColor set];
 		[path fill];
 	}

--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -374,7 +374,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
         isResizing = NO;
 		
         [self.window enableCursorRects];
-        [self.window resetCursorRects];
+        [self.window invalidateCursorRectsForView:self];
         
 		// update cache of column rects
 		


### PR DESCRIPTION
* Gray out selected headers when the window is not key (or the grid is not the first responder)

* Use `systemYellowColor` for the grab handle (very close to the previous defined color)

* Fill the selection rectangle *before* drawing the cell interiors. This fixes a washed-out look in Dark Mode.

* Explicitly set the cell's `textColor` when editing a cell. This fixes a bug in Dark Mode where the text turns black (i.e. invisible) when editing a cell.

* Prefer `[NSWindow invalidateCursorRectsForView:]` over `[NSWindow resetCursorRects]`

* Break `[MBTableGridContentView drawRect:]` into several functions