### PR TITLE
Footer menu

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -1222,7 +1222,7 @@ cells. A cell can individually override this behavior. */
 /**
  * @brief   Informs the delegate that the column footer's contextual menu is about to be displayed.
  *          The menu items can then be customized for the particular column.
- *          (The column header menu can be set via the \c menu property of the table grid's \c columnFooterView.)
+ *          (The column footer menu can be set via the \c menu property of the table grid's \c columnFooterView.)
  *
  *  @param  aTableGrid      The table grid object that will display the menu
  *

--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -1213,10 +1213,28 @@ cells. A cell can individually override this behavior. */
  *
  *  @param  columnIndex     The column that was clicked (right-clicked or Control-clicked)
  *
+ *  @see    tableGrid:willDisplayFooterMenu:forColumn:
  *  @see    tableGrid:willDisplayHeaderMenu:forRow:
  */
 
 - (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayHeaderMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex;
+
+/**
+ * @brief   Informs the delegate that the column footer's contextual menu is about to be displayed.
+ *          The menu items can then be customized for the particular column.
+ *          (The column header menu can be set via the \c menu property of the table grid's \c columnFooterView.)
+ *
+ *  @param  aTableGrid      The table grid object that will display the menu
+ *
+ *  @param  menu                    The menu about to be displayed
+ *
+ *  @param  columnIndex     The column that was clicked (right-clicked or Control-clicked)
+ *
+ *  @see    tableGrid:willDisplayHeaderMenu:forRow:
+ *  @see    tableGrid:willDisplayHeaderMenu:forColumn:
+ */
+
+- (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayFooterMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex;
 
 /**
  * @brief   Informs the delegate that the row header's contextual menu is about to be displayed.
@@ -1230,6 +1248,7 @@ cells. A cell can individually override this behavior. */
  *  @param  rowIndex            The row that was clicked (right-clicked or Control-clicked)
  *
  *  @see    tableGrid:willDisplayHeaderMenu:forColumn:
+ *  @see    tableGrid:willDisplayFooterMenu:forColumn:
  */
 
 - (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayHeaderMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex;

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -2086,6 +2086,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
         [self.delegate tableGrid:self willDisplayHeaderMenu:menu forColumn:columnIndex];
 }
 
+- (void)_willDisplayFooterMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex {
+    if ([self.delegate respondsToSelector:@selector(tableGrid:willDisplayFooterMenu:forColumn:)])
+        [self.delegate tableGrid:self willDisplayFooterMenu:menu forColumn:columnIndex];
+}
+
 - (void)_willDisplayHeaderMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex {
     if ([self.delegate respondsToSelector:@selector(tableGrid:willDisplayHeaderMenu:forRow:)])
         [self.delegate tableGrid:self willDisplayHeaderMenu:menu forRow:rowIndex];

--- a/MBTableGridFooterView.h
+++ b/MBTableGridFooterView.h
@@ -64,7 +64,7 @@
  */
 
 /**
- * @brief		Returns the rectangle containing the header tile for
+ * @brief		Returns the rectangle containing the footer tile for
  *				the column at \c columnIndex.
  * @param		columnIndex	The index of the column containing the
  *							header whose rectangle you want.
@@ -72,9 +72,9 @@
  *				\c columnIndex. Returns \c NSZeroRect if \c columnIndex 
  *				lies outside the range of valid column indices for the 
  *				receiver.
- * @see			headerRectOfRow:
  */
-//- (NSRect)headerRectOfColumn:(NSUInteger)columnIndex;
+
+- (NSRect)footerRectOfColumn:(NSUInteger)columnIndex;
 
 /**
  * @}

--- a/MBTableGridFooterView.h
+++ b/MBTableGridFooterView.h
@@ -28,8 +28,8 @@
 @class MBTableGrid, MBFooterTextCell;
 
 /**
- * @brief		\c MBTableGridHeaderView deals with the
- *				display and interaction with grid headers.
+ * @brief		\c MBTableGridFooterView deals with the
+ *				display and interaction with grid footers.
  */
 @interface MBTableGridFooterView : NSView {
     MBFooterTextCell *_defaultCell;
@@ -67,8 +67,8 @@
  * @brief		Returns the rectangle containing the footer tile for
  *				the column at \c columnIndex.
  * @param		columnIndex	The index of the column containing the
- *							header whose rectangle you want.
- * @return		A rectangle locating the header for the column at
+ *							footer whose rectangle you want.
+ * @return		A rectangle locating the footer for the column at
  *				\c columnIndex. Returns \c NSZeroRect if \c columnIndex 
  *				lies outside the range of valid column indices for the 
  *				receiver.

--- a/MBTableGridFooterView.m
+++ b/MBTableGridFooterView.m
@@ -33,6 +33,7 @@
 - (NSCell *)_footerCellForColumn:(NSUInteger)columnIndex;
 - (id)_footerValueForColumn:(NSUInteger)columnIndex;
 - (void)_setFooterValue:(id)value forColumn:(NSUInteger)columnIndex;
+- (void)_willDisplayFooterMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex;
 @end
 
 @implementation MBTableGridFooterView
@@ -76,6 +77,14 @@
 - (BOOL)isFlipped
 {
 	return YES;
+}
+
+- (NSMenu *)menuForEvent:(NSEvent *)theEvent {
+    NSPoint event_location = theEvent.locationInWindow;
+    NSPoint local_point = [self convertPoint:event_location fromView:nil];
+    NSInteger column = [self.tableGrid columnAtPoint:[self convertPoint:local_point toView:self.tableGrid]];
+    [self.tableGrid _willDisplayFooterMenu:self.menu forColumn:column];
+    return self.menu;
 }
 
 - (void)mouseDown:(NSEvent *)theEvent


### PR DESCRIPTION
New delegate method:

```
- (void)tableGrid:(MBTableGrid *)aTableGrid
         willDisplayFooterMenu:(NSMenu *)menu
         forColumn:(NSUInteger)columnIndex;
```

Mirrors the existing methods for handling header menus