### PR TITLE
Let AppKit decide when to end cell editing

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -440,9 +440,6 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 #pragma mark Mouse Events
 
 - (void)mouseDown:(NSEvent *)theEvent {
-	// End editing (if necessary)
-	[self.cell endEditing:[self.window fieldEditor:NO forObject:contentView]];
-
 	// If we're not the first responder, we need to be
 	if (self.window.firstResponder != self) {
 		[self.window makeFirstResponder:self];


### PR DESCRIPTION
Removing this call to `[NSCell endEditing:]` noticeably improves performance. With the call in place, every mouse click results in a complete redraw of the table grid, which makes things laggy e.g. when clicking on column headers.

Testing on Catalina, I don't see any difference in behavior by removing the call and letting Cocoa figure out when to end the field editor through the standard AppKit mechanisms. I can test on older versions of macOS if needed, but I suspect that the `makeFirstResponder` in the next line is enough to end the editing session.