### PR TITLE
Support for row footers

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -115,17 +115,21 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
 	NSScrollView *rowHeaderScrollView;
 	MBTableGridHeaderView *rowHeaderView;
 	
-	/* Footer */
+	/* Footers */
 	NSScrollView *columnFooterScrollView;
 	MBTableGridFooterView *columnFooterView;
+    NSScrollView *rowFooterScrollView;
+    MBTableGridFooterView *rowFooterView;
 	
 	/* Content */
 	NSScrollView *contentScrollView;
 	MBTableGridContentView *contentView;
 
     /* Corners */
-    NSVisualEffectView *headerCornerView;
-    NSVisualEffectView *footerCornerView;
+    NSVisualEffectView *leadingHeaderCornerView;
+    NSVisualEffectView *leadingFooterCornerView;
+    NSVisualEffectView *trailingHeaderCornerView;
+    NSVisualEffectView *trailingFooterCornerView;
 	
 	/* Sticky Edges (for Shift+Arrow expansions) */
 	MBHorizontalEdge stickyColumnEdge;
@@ -142,9 +146,11 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
 @property (getter=isColumnHeaderVisible, nonatomic, assign) BOOL columnHeaderVisible;
 @property (getter=isColumnFooterVisible, nonatomic, assign) BOOL columnFooterVisible;
 @property (getter=isRowHeaderVisible, nonatomic, assign) BOOL rowHeaderVisible;
+@property (getter=isRowHeaderVisible, nonatomic, assign) BOOL rowFooterVisible;
 
 @property (nonatomic, assign) CGFloat rowHeaderWidth;
 @property (nonatomic, assign) CGFloat columnFooterHeight;
+@property (nonatomic, assign) CGFloat rowFooterWidth;
 @property (nonatomic, assign) CGFloat minimumColumnWidth;
 
 @property (nonatomic) NSEdgeInsets contentInsets;
@@ -767,7 +773,7 @@ cells. A cell can individually override this behavior. */
  * @}
  */
 
-#pragma mark Footer
+#pragma mark Footers
 
 @optional
 
@@ -783,6 +789,20 @@ cells. A cell can individually override this behavior. */
  *  @return     The cell for the specified column footer.
  */
 - (NSCell *)tableGrid:(MBTableGrid *)aTableGrid footerCellForColumn:(NSUInteger)columnIndex;
+
+/**
+ *  @brief      Returns the cell for the footer of the specified row.
+ *
+ * @details        Optional; if not implemented, or returns nil, an empty footer is
+ *                displayed for this row.
+ *
+ *  @param      aTableGrid  The table grid that sent the message.
+ *  @param      rowIndex A row in \c aTableGrid.
+ *
+ *  @return     The cell for the specified row footer.
+ */
+- (NSCell *)tableGrid:(MBTableGrid *)aTableGrid footerCellForRow:(NSUInteger)rowIndex;
+
 
 /**
  * @brief		Returns the data object for the footer of the specified column.
@@ -1187,6 +1207,8 @@ cells. A cell can individually override this behavior. */
 - (void)tableGrid:(MBTableGrid *)aTableGrid didAddRows:(NSIndexSet *)rowIndexes;
 
 - (void)tableGrid:(MBTableGrid*)aTableGrid footerCellClicked:(NSCell*)cell forColumn:(NSUInteger)columnIndex withEvent:(NSEvent*)theEvent;
+
+- (void)tableGrid:(MBTableGrid*)aTableGrid footerCellClicked:(NSCell*)cell forRow:(NSUInteger)columnIndex withEvent:(NSEvent*)theEvent;
 
 #pragma mark Sorting
 

--- a/MBTableGrid.xcodeproj/project.pbxproj
+++ b/MBTableGrid.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		173D292D1AA1779F009945FC /* MBFooterTextCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 173D292B1AA1779F009945FC /* MBFooterTextCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		173D292E1AA1779F009945FC /* MBFooterTextCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 173D292C1AA1779F009945FC /* MBFooterTextCell.m */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		C63DB4CD1A19E2F70069BF5D /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C63DB4CB1A19DA030069BF5D /* QuickLook.framework */; };
@@ -30,6 +28,7 @@
 		DC7EBF4A23D21AE800F75351 /* MBTableGridTextFinderClient.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7EBF4823D21AE800F75351 /* MBTableGridTextFinderClient.m */; };
 		DCAE58A523D9EC7300A3AAE0 /* NSScrollView+InsetRectangles.h in Headers */ = {isa = PBXBuildFile; fileRef = DCAE58A323D9EC7200A3AAE0 /* NSScrollView+InsetRectangles.h */; };
 		DCAE58A623D9EC7300A3AAE0 /* NSScrollView+InsetRectangles.m in Sources */ = {isa = PBXBuildFile; fileRef = DCAE58A423D9EC7200A3AAE0 /* NSScrollView+InsetRectangles.m */; };
+		DCBB2F542461A173003D3178 /* MBTableGridFooterTextCell.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBB2F522461A161003D3178 /* MBTableGridFooterTextCell.m */; };
 		DCDB6EDB23C905C200F348EB /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DCDB6EDA23C905C200F348EB /* MainMenu.xib */; };
 		E2E62BAC1781C33500F36275 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2E62BAB1781C33400F36275 /* Cocoa.framework */; };
 		E2E62BBA1781C37300F36275 /* MBTableGrid.m in Sources */ = {isa = PBXBuildFile; fileRef = C9412A3E0D8A061C00E9E614 /* MBTableGrid.m */; };
@@ -48,8 +47,6 @@
 /* Begin PBXFileReference section */
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		13E42FB307B3F0F600E4EEF1 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
-		173D292B1AA1779F009945FC /* MBFooterTextCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBFooterTextCell.h; sourceTree = SOURCE_ROOT; };
-		173D292C1AA1779F009945FC /* MBFooterTextCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBFooterTextCell.m; sourceTree = SOURCE_ROOT; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
@@ -85,6 +82,8 @@
 		DC7EBF4823D21AE800F75351 /* MBTableGridTextFinderClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBTableGridTextFinderClient.m; sourceTree = SOURCE_ROOT; };
 		DCAE58A323D9EC7200A3AAE0 /* NSScrollView+InsetRectangles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSScrollView+InsetRectangles.h"; sourceTree = SOURCE_ROOT; };
 		DCAE58A423D9EC7200A3AAE0 /* NSScrollView+InsetRectangles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSScrollView+InsetRectangles.m"; sourceTree = SOURCE_ROOT; };
+		DCBB2F512461A161003D3178 /* MBTableGridFooterTextCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBTableGridFooterTextCell.h; sourceTree = SOURCE_ROOT; };
+		DCBB2F522461A161003D3178 /* MBTableGridFooterTextCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBTableGridFooterTextCell.m; sourceTree = SOURCE_ROOT; };
 		DCDB6EDA23C905C200F348EB /* MainMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainMenu.xib; sourceTree = "<group>"; };
 		E2E62BAA1781C33400F36275 /* MBTableGrid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MBTableGrid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2E62BAB1781C33400F36275 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -217,10 +216,10 @@
 				C6BF26861A4AC4EE008EB93F /* MBTableGridFooterView.m */,
 				C9412B380D8B2F5400E9E614 /* MBTableGridHeaderView.h */,
 				C9412B390D8B2F5400E9E614 /* MBTableGridHeaderView.m */,
-				173D292B1AA1779F009945FC /* MBFooterTextCell.h */,
-				173D292C1AA1779F009945FC /* MBFooterTextCell.m */,
 				C9412A490D8A294F00E9E614 /* MBTableGridHeaderCell.h */,
 				C9412A4A0D8A294F00E9E614 /* MBTableGridHeaderCell.m */,
+				DCBB2F512461A161003D3178 /* MBTableGridFooterTextCell.h */,
+				DCBB2F522461A161003D3178 /* MBTableGridFooterTextCell.m */,
 				C9412D7B0D8B5AB900E9E614 /* MBTableGridCell.h */,
 				C9412D7C0D8B5AB900E9E614 /* MBTableGridCell.m */,
 				CA46E3611A09726A00C43B4B /* MBTableGridEditable.h */,
@@ -235,7 +234,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				173D292D1AA1779F009945FC /* MBFooterTextCell.h in Headers */,
 				E2E62BFB1781C53800F36275 /* MBTableGridCell.h in Headers */,
 				CA46E3621A09726A00C43B4B /* MBTableGridEditable.h in Headers */,
 				DC7EBF4123D2157B00F75351 /* MBTableGridContentScrollView.h in Headers */,
@@ -357,10 +355,10 @@
 				E2E62BBB1781C37600F36275 /* MBTableGridContentView.m in Sources */,
 				DC7EBF4223D2157B00F75351 /* MBTableGridContentScrollView.m in Sources */,
 				E2E62BBC1781C37800F36275 /* MBTableGridHeaderView.m in Sources */,
-				173D292E1AA1779F009945FC /* MBFooterTextCell.m in Sources */,
 				E2E62BBD1781C37B00F36275 /* MBTableGridHeaderCell.m in Sources */,
 				E2E62BBE1781C38000F36275 /* MBTableGridCell.m in Sources */,
 				DCAE58A623D9EC7300A3AAE0 /* NSScrollView+InsetRectangles.m in Sources */,
+				DCBB2F542461A173003D3178 /* MBTableGridFooterTextCell.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -50,8 +50,6 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 - (NSColor *)_selectionColor;
 - (BOOL)_containsFirstResponder;
 - (NSCell *)_footerCellForColumn:(NSUInteger)columnIndex;
-- (id)_footerValueForColumn:(NSUInteger)columnIndex;
-- (void)_setFooterValue:(id)value forColumn:(NSUInteger)columnIndex;
 @end
 
 @interface MBTableGridContentView (Cursors)

--- a/MBTableGridController.m
+++ b/MBTableGridController.m
@@ -25,7 +25,7 @@
 
 #import "MBTableGridController.h"
 #import "MBTableGridCell.h"
-#import "MBFooterTextCell.h"
+#import "MBTableGridFooterTextCell.h"
 
 NSString* kAutosavedColumnWidthKey = @"AutosavedColumnWidth";
 NSString* kAutosavedColumnIndexKey = @"AutosavedColumnIndex";
@@ -39,7 +39,7 @@ NSString * const PasteboardTypeColumnClass = @"pasteboardTypeColumnClass";
 
 @interface MBTableGridController()
 @property (nonatomic, strong) MBTableGridCell *textCell;
-@property (nonatomic, strong) MBFooterTextCell *footerTextCell;
+@property (nonatomic, strong) MBTableGridFooterTextCell *footerTextCell;
 @property (nonatomic, strong) NSDictionary *columnWidths;
 @property (nonatomic, strong) NSMutableArray *columnIdentifiers;
 @end
@@ -79,8 +79,7 @@ NSString * const PasteboardTypeColumnClass = @"pasteboardTypeColumnClass";
 	[tableGrid registerForDraggedTypes:@[NSStringPboardType]];
 	
 	self.textCell = [[MBTableGridCell alloc] initTextCell:@""];
-
-	self.footerTextCell = [[MBFooterTextCell alloc] initTextCell:@""];
+	self.footerTextCell = [[MBTableGridFooterTextCell alloc] initTextCell:@""];
 }
 
 -(NSString *) genRandStringLength: (int) len
@@ -194,12 +193,8 @@ NSString * const PasteboardTypeColumnClass = @"pasteboardTypeColumnClass";
 
 - (NSCell *)tableGrid:(MBTableGrid *)aTableGrid footerCellForColumn:(NSUInteger)columnIndex;
 {
+    self.footerTextCell.title = [NSString stringWithFormat:@"Footer %lu", columnIndex];
 	return self.footerTextCell;
-}
-
-- (id)tableGrid:(MBTableGrid *)aTableGrid footerValueForColumn:(NSUInteger)columnIndex;
-{
-	return [NSString stringWithFormat:@"Footer %lu", columnIndex];
 }
 
 #pragma mark Dragging

--- a/MBTableGridFooterTextCell.h
+++ b/MBTableGridFooterTextCell.h
@@ -7,6 +7,6 @@
 
 #import "MBTableGridCell.h"
 
-@interface MBFooterTextCell : MBTableGridCell
+@interface MBTableGridFooterTextCell : MBTableGridCell
 
 @end

--- a/MBTableGridFooterTextCell.m
+++ b/MBTableGridFooterTextCell.m
@@ -5,9 +5,9 @@
 //  Created by David Sinclair on 2015-02-27.
 //
 
-#import "MBFooterTextCell.h"
+#import "MBTableGridFooterTextCell.h"
 
-@interface MBFooterTextCell ()
+@interface MBTableGridFooterTextCell ()
 
 @property (nonatomic, strong) NSFont *attributedTitleFont;
 
@@ -15,7 +15,7 @@
 
 #pragma mark -
 
-@implementation MBFooterTextCell
+@implementation MBTableGridFooterTextCell
 
 - (NSAttributedString *)attributedTitle
 {

--- a/MBTableGridFooterView.h
+++ b/MBTableGridFooterView.h
@@ -85,8 +85,23 @@
  *				\c columnIndex. Returns \c NSZeroRect if \c columnIndex 
  *				lies outside the range of valid column indices for the 
  *				receiver.
+ * @see         footerRectOfRow:
  */
 - (NSRect)footerRectOfColumn:(NSUInteger)columnIndex;
+
+/**
+ * @brief        Returns the rectangle containing the footer tile for
+ *                the row at \c rowIndex (vertical footers only).
+ * @param        rowIndex    The index of the row containing the
+ *                            footer whose rectangle you want.
+ * @return        A rectangle locating the footer for the row at
+ *                \c rowIndex. Returns \c NSZeroRect if \c rowIndex
+ *                lies outside the range of valid row indices for the
+ *                receiver.
+ * @see           headerRectOfRow:
+ * @see           vertical
+ */
+- (NSRect)footerRectOfRow:(NSUInteger)rowIndex;
 
 /**
  * @}

--- a/MBTableGridFooterView.h
+++ b/MBTableGridFooterView.h
@@ -25,18 +25,32 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class MBTableGrid, MBFooterTextCell;
+@class MBTableGrid;
 
 /**
  * @brief		\c MBTableGridFooterView deals with the
  *				display and interaction with grid footers.
  */
 @interface MBTableGridFooterView : NSView {
-    MBFooterTextCell *_defaultCell;
     NSInteger editedColumn;
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect andTableGrid:(MBTableGrid *)tableGrid;
+
+/**
+ * @name        Display Properties
+ */
+/**
+ * @{
+ */
+
+/**
+ * @brief        The orientation of the receiver.
+ */
+@property (nonatomic, getter=isVertical) BOOL vertical;
+/**
+* @}
+*/
 
 /**
  * @name		The Grid View
@@ -49,7 +63,6 @@
  * @brief		Returns the \c MBTableGrid the receiver 
  *				belongs to.
  */
-//- (MBTableGrid *)tableGrid;
 @property (nonatomic, weak) MBTableGrid* tableGrid;
 
 /**
@@ -73,7 +86,6 @@
  *				lies outside the range of valid column indices for the 
  *				receiver.
  */
-
 - (NSRect)footerRectOfColumn:(NSUInteger)columnIndex;
 
 /**

--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -35,7 +35,6 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 @interface MBTableGrid (Private)
 - (NSString *)_headerStringForColumn:(NSUInteger)columnIndex;
 - (NSString *)_headerStringForRow:(NSUInteger)rowIndex;
-- (MBTableGridContentView *)_contentView;
 - (void)_dragColumnsWithEvent:(NSEvent *)theEvent;
 - (void)_dragRowsWithEvent:(NSEvent *)theEvent;
 - (void)_sortButtonClickedForColumn:(NSUInteger)column;
@@ -159,7 +158,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 		NSUInteger numberOfRows = self.tableGrid.numberOfRows;
 		headerCell.orientation = self.orientation;
 
-		CGFloat rowHeight = [self.tableGrid _contentView].rowHeight;
+        CGFloat rowHeight = self.tableGrid.contentView.rowHeight;
 		NSUInteger row = MAX(0, floor(rect.origin.y / rowHeight));
 		NSUInteger endRow = MIN(numberOfRows, ceil((rect.origin.y + rect.size.height) / rowHeight));
 
@@ -455,7 +454,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 
 - (NSRect)headerRectOfColumn:(NSUInteger)columnIndex
 {
-	NSRect rect = [self.tableGrid._contentView rectOfColumn:columnIndex];
+	NSRect rect = [self.tableGrid.contentView rectOfColumn:columnIndex];
 	rect.size.height = NSHeight(self.bounds);
 	
 	return rect;
@@ -463,7 +462,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 
 - (NSRect)headerRectOfRow:(NSUInteger)rowIndex
 {
-	NSRect rect = [self.tableGrid._contentView rectOfRow:rowIndex];
+	NSRect rect = [self.tableGrid.contentView rectOfRow:rowIndex];
 	rect.size.width = NSWidth(self.bounds);
 	
 	return rect;


### PR DESCRIPTION
* Put a vertical `MBTableGridFooterView` on the right side of the grid (hidden by default). New public properties `rowFooterVisible` and `rowFooterWidth`, and new delegate methods

```objective-c
// Supply a cell
- (NSCell *)tableGrid:(MBTableGrid *)aTableGrid footerCellForRow:(NSUInteger)rowIndex;

// Handle a click
- (void)tableGrid:(MBTableGrid*)aTableGrid footerCellClicked:(NSCell*)cell
              forRow:(NSUInteger)columnIndex withEvent:(NSEvent*)theEvent;
```

* Fix up the example project to use column footers properly

* Get rid of some unused methods

* Add corner views (`NSVisualEffectView`s) to the top right and bottom right