### PR TITLE
AppKit fixes

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -463,6 +463,10 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	}
 }
 
+- (void)mouseUp:(NSEvent *)theEvent {
+    // Don't pass it up the view hierarchy
+}
+
 #pragma mark Keyboard Events
 
 - (void)keyDown:(NSEvent *)theEvent {
@@ -577,7 +581,8 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		row = self.selectedRowIndexes.lastIndex;
 	}
 
-    if (row <= 0) { return; }
+    if (row <= 0 || row == NSNotFound || column == NSNotFound)
+        return;
 
 	self.selectedColumnIndexes = [NSIndexSet indexSetWithIndex:column];
 	self.selectedRowIndexes = [NSIndexSet indexSetWithIndex:(row - 1)];
@@ -622,7 +627,8 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		row = self.selectedRowIndexes.lastIndex;
 	}
 
-    if (row >= (_numberOfRows - 1)) { return; }
+    if (row >= (_numberOfRows - 1) || column == NSNotFound || row == NSNotFound)
+        return;
 
 	self.selectedColumnIndexes = [NSIndexSet indexSetWithIndex:column];
 	self.selectedRowIndexes = [NSIndexSet indexSetWithIndex:(row + 1)];
@@ -668,7 +674,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		row = self.selectedRowIndexes.lastIndex;
 	}
 
-    if (column == 0)
+    if (column == 0 || column == NSNotFound || row == NSNotFound)
         return;
 
     self.selectedColumnIndexes = [NSIndexSet indexSetWithIndex:(column - 1)];
@@ -714,7 +720,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 		row = self.selectedRowIndexes.lastIndex;
 	}
 
-    if (column >= (_numberOfColumns - 1))
+    if (column >= (_numberOfColumns - 1) || column == NSNotFound || row == NSNotFound)
         return;
 
     self.selectedColumnIndexes = [NSIndexSet indexSetWithIndex:(column + 1)];


### PR DESCRIPTION
* Don't pass `mouseUp:` events up through the view hierarchy (we intercept `mouseDown:` so we should intercept its twin brother too)

* Don't crash when keyboard navigating with an empty selection

* Use a non-repeating timer for autoscroll. This addresses a hang that I observed when drawing took longer than the timer's firing interval. Somehow the run loop got gummed up. I'm still seeing occasional hangs with long drawing times, so this change might just be superstitious, but it's easy enough to change.