### PR TITLE
New read-only properties

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -153,6 +153,11 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
 @property (nonatomic, assign) CGFloat rowFooterWidth;
 @property (nonatomic, assign) CGFloat minimumColumnWidth;
 
+@property (nonatomic, readonly) NSView *leadingHeaderCornerView;
+@property (nonatomic, readonly) NSView *leadingFooterCornerView;
+@property (nonatomic, readonly) NSView *trailingHeaderCornerView;
+@property (nonatomic, readonly) NSView *trailingFooterCornerView;
+
 @property (nonatomic) NSEdgeInsets contentInsets;
 @property (nonatomic, assign) NSUInteger sortColumnIndex; // NSNotFound for none
 @property (getter=isSortColumnAscending, nonatomic, assign) BOOL sortColumnAscending;
@@ -219,7 +224,8 @@ typedef NS_ENUM(NSUInteger, MBVerticalEdge) {
  *
  */
 
-@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSValue *> *columnRects;
+@property (nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *columnRects;
+@property (nonatomic, readonly) NSMutableDictionary<NSNumber *, NSNumber *> *columnWidths;
 
 
 - (void)resizeColumnWithIndex:(NSUInteger)columnIndex width:(float)w;
@@ -527,6 +533,7 @@ cells. A cell can individually override this behavior. */
  *
  * @see			rowHeaderView
  * @see         columnFooterView
+ * @see         rowFooterView
  */
 
 @property (nonatomic, readonly) MBTableGridHeaderView* columnHeaderView;
@@ -540,6 +547,7 @@ cells. A cell can individually override this behavior. */
  *
  * @see            rowHeaderView
  * @see            columnHeaderView
+ * @see            rowFooterView
  */
 
 @property (nonatomic, readonly) MBTableGridFooterView* columnFooterView;
@@ -549,13 +557,28 @@ cells. A cell can individually override this behavior. */
  *				to draw headers beside rows.
  *
  * @return		The \c MBTableGridHeaderView object used to draw
- *				column headers.
+ *				row headers.
  *
+ * @see            rowFooterView
  * @see            columnHeaderView
  * @see            columnFooterView
  */
 
 @property (nonatomic, readonly) MBTableGridHeaderView* rowHeaderView;
+
+/**
+ * @brief        Returns the \c MBTableGridFooterView object used
+ *                to draw footers beside rows.
+ *
+ * @return        The \c MBTableGridFooterView object used to draw
+ *                row footers.
+ *
+ * @see            rowHeaderView
+ * @see            columnHeaderView
+ * @see            columnFooterView
+ */
+
+@property (nonatomic, readonly) MBTableGridFooterView* rowFooterView;
 
 /**
  * @brief		Returns the receiver's content view.

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -122,6 +122,18 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 @implementation MBTableGrid
 
+@synthesize columnHeaderView=columnHeaderView;
+@synthesize columnFooterView=columnFooterView;
+@synthesize rowHeaderView=rowHeaderView;
+@synthesize rowFooterView=rowFooterView;
+
+@synthesize leadingHeaderCornerView=leadingHeaderCornerView;
+@synthesize leadingFooterCornerView=leadingFooterCornerView;
+@synthesize trailingHeaderCornerView=trailingHeaderCornerView;
+@synthesize trailingFooterCornerView=trailingFooterCornerView;
+
+@synthesize contentView=contentView;
+
 #pragma mark -
 #pragma mark Initialization & Superclass Overrides
 
@@ -270,7 +282,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
         self.previousVerticalSelectionDirection = MBVerticalEdgeTop;
         self.previousHorizontalSelectionDirection = MBHorizontalEdgeLeft;
 		
-		self.columnRects = [NSMutableDictionary dictionary];
+		_columnRects = [[NSMutableDictionary alloc] init];
         [self registerForDraggedTypes:@[MBTableGridColumnDataType, MBTableGridRowDataType]];
         
         _textFinder = [[NSTextFinder alloc] init];
@@ -1642,26 +1654,6 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 #pragma mark Auxiliary Views
-
-- (MBTableGridHeaderView *)columnHeaderView {
-	return columnHeaderView;
-}
-
-- (MBTableGridHeaderView *)rowHeaderView {
-	return rowHeaderView;
-}
-
-- (MBTableGridFooterView *)columnFooterView {
-    return columnFooterView;
-}
-
-- (MBTableGridFooterView *)rowFooterView {
-    return rowFooterView;
-}
-
-- (MBTableGridContentView *)contentView {
-	return contentView;
-}
 
 - (BOOL)isColumnHeaderVisible {
     return columnHeaderScrollView.frame.size.height > 0.0;

--- a/MBTableGridContentView.h
+++ b/MBTableGridContentView.h
@@ -65,9 +65,6 @@ typedef NS_ENUM(NSUInteger, MBTableGridTrackingPart)
     MBTableGridTrackingPart shouldDrawFillPart;
 	
 	MBTableGridCell *_defaultCell;
-    
-    NSMutableArray<NSNumber *> *columnWidths;
-    
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect andTableGrid:(MBTableGrid*)tableGrid;


### PR DESCRIPTION
* `columnWidths` - The point-size width of each column

* `rowFooterView` - The footer view that runs along the trailing edge of the grid

* `leadingHeaderCornerView` and its three bridge partners - the NSViews (really NSVisualEffectViews) in each corner of the grid, ideal for placing custom widgets