### PR TITLE
New delegate methods

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -1103,13 +1103,25 @@ cells. A cell can individually override this behavior. */
  *
  * @param        aTableGrid        The table grid object informing the delegate
  *                                about the double-click event
- * @param        columnIndex        The double-clicked row in \c aTableGrid.
+ * @param        rowIndex        The double-clicked row in \c aTableGrid.
  *
  *
  * @see            tableGrid:didDoubleClickColumn:
  */
 - (void)tableGrid:(MBTableGrid *)aTableGrid didDoubleClickRow:(NSUInteger)rowIndex;
 
+/**
+ * @brief        Tells the delegate that the specified cell was double-clicked
+ *
+ * @param        aTableGrid        The table grid object informing the delegate
+ *                                about the double-click event
+ * @param        columnIndex        The double-clicked column in \c aTableGrid.
+ * @param        rowIndex        The double-clicked column in \c aTableGrid.
+ *
+ *
+ * @see            tableGrid:didDoubleClickColumn:
+*/
+- (void)tableGrid:(MBTableGrid *)aTableGrid didDoubleClickColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 
 /**
  * @}
@@ -1238,6 +1250,7 @@ cells. A cell can individually override this behavior. */
  *
  *  @see    tableGrid:willDisplayFooterMenu:forColumn:
  *  @see    tableGrid:willDisplayHeaderMenu:forRow:
+ *  @see    tableGrid:willDisplayFooterMenu:forRow:
  */
 
 - (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayHeaderMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex;
@@ -1255,6 +1268,7 @@ cells. A cell can individually override this behavior. */
  *
  *  @see    tableGrid:willDisplayHeaderMenu:forRow:
  *  @see    tableGrid:willDisplayHeaderMenu:forColumn:
+ *  @see    tableGrid:willDisplayFooterMenu:forRow:
  */
 
 - (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayFooterMenu:(NSMenu *)menu forColumn:(NSUInteger)columnIndex;
@@ -1272,8 +1286,27 @@ cells. A cell can individually override this behavior. */
  *
  *  @see    tableGrid:willDisplayHeaderMenu:forColumn:
  *  @see    tableGrid:willDisplayFooterMenu:forColumn:
+ *  @see    tableGrid:willDisplayFooterMenu:forRow:
  */
 
 - (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayHeaderMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex;
+
+/**
+ * @brief   Informs the delegate that the row footer's contextual menu is about to be displayed.
+ *          The menu items can then be customized for the particular row.
+ *          (The row footer menu can be set via the \c menu property of the table grid's \c rowFooterView.)
+ *
+ *  @param  aTableGrid      The table grid object that will display the menu
+ *
+ *  @param  menu                    The menu about to be displayed
+ *
+ *  @param  rowIndex            The row that was clicked (right-clicked or Control-clicked)
+ *
+ *  @see    tableGrid:willDisplayHeaderMenu:forColumn:
+ *  @see    tableGrid:willDisplayHeaderMenu:forRow:
+ *  @see    tableGrid:willDisplayFooterMenu:forColumn:
+ */
+
+- (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayFooterMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex;
 
 @end

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -50,6 +50,9 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 - (NSColor *)_selectionColor;
 - (BOOL)_containsFirstResponder;
 - (NSCell *)_footerCellForColumn:(NSUInteger)columnIndex;
+- (void)_didDoubleClickColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
+- (NSRange)_rangeOfRowsIntersectingRect:(NSRect)rect;
+- (NSRange)_rangeOfColumnsIntersectingRect:(NSRect)rect;
 @end
 
 @interface MBTableGridContentView (Cursors)
@@ -117,31 +120,13 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 }
 
 - (void)drawCellInteriorsInRect:(NSRect)rect {
-    NSUInteger numberOfColumns = _tableGrid.numberOfColumns;
-    NSUInteger numberOfRows = _tableGrid.numberOfRows;
+    NSRange columnRange = [_tableGrid _rangeOfColumnsIntersectingRect:[self convertRect:rect toView:_tableGrid]];
+    NSRange rowRange = [_tableGrid _rangeOfRowsIntersectingRect:[self convertRect:rect toView:_tableGrid]];
     
-    NSUInteger firstColumn = NSNotFound;
-    NSUInteger lastColumn = (numberOfColumns==0) ? 0 : numberOfColumns - 1;
-    NSUInteger firstRow = MAX(0, floor(rect.origin.y / self.rowHeight));
-    NSUInteger lastRow = (numberOfRows==0) ? 0 : MIN(numberOfRows - 1, ceil((rect.origin.y + rect.size.height)/self.rowHeight));
-    
-    // Find the columns to draw
-    NSUInteger column = 0;
-    while (column < numberOfColumns) {
-        NSRect columnRect = [self rectOfColumn:column];
-        if (firstColumn == NSNotFound && NSMinX(rect) >= NSMinX(columnRect) && NSMinX(rect) <= NSMaxX(columnRect)) {
-            firstColumn = column;
-        } else if (firstColumn != NSNotFound && NSMaxX(rect) >= NSMinX(columnRect) && NSMaxX(rect) <= NSMaxX(columnRect)) {
-            lastColumn = column;
-            break;
-        }
-        column++;
-    }
-    
-    column = firstColumn;
-    while (column <= lastColumn) {
-        NSUInteger row = firstRow;
-        while (row <= lastRow) {
+    NSUInteger column = columnRange.location;
+    while (column != NSNotFound && column < NSMaxRange(columnRange)) {
+        NSUInteger row = rowRange.location;
+        while (row != NSNotFound && row < NSMaxRange(rowRange)) {
             NSRect cellFrame = [self frameOfCellAtColumn:column row:row];
             if ([self needsToDrawRect:cellFrame] && (!(row == editedRow && column == editedColumn))) {
                 // Only fetch the cell if we need to
@@ -387,7 +372,9 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 			[self.tableGrid _setStickyColumn:MBHorizontalEdgeLeft row:MBVerticalEdgeTop];
 		}
     // Edit cells on double click if they don't already edit on first click
-	}
+    } else if (theEvent.clickCount == 2) {
+        [self.tableGrid _didDoubleClickColumn:mouseDownColumn row:mouseDownRow];
+    }
 
 	// Any cells that should edit on first click are handled here
 	if (cellEditsOnFirstClick) {
@@ -795,7 +782,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	NSInteger column = 0;
 	while(column < self.tableGrid.numberOfColumns) {
 		NSRect columnFrame = [self rectOfColumn:column];
-		if(aPoint.x >= columnFrame.origin.x && aPoint.x < (columnFrame.origin.x + columnFrame.size.width)) {
+        if(aPoint.x >= NSMinX(columnFrame) && aPoint.x < NSMaxX(columnFrame)) {
 			return column;
 		}
 		column++;


### PR DESCRIPTION
Delegate method that receives double-click events on individual cells:

    - (void)tableGrid:(MBTableGrid *)aTableGrid didDoubleClickColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;

Delegate method called before displaying a menu on the row footer:

    - (void)tableGrid:(MBTableGrid *)aTableGrid willDisplayFooterMenu:(NSMenu *)menu forRow:(NSUInteger)rowIndex;

These are modeled closely off of existing delegate methods.

This commit also consolidates rect-to-range logic in various places with a new internal API on MBTableGrid:

    - (NSRange)_rangeOfColumnsIntersectingRect:(NSRect)rect;
    - (NSRange)_rangeOfRowsIntersectingRect:(NSRect)rect;

So future improvements e.g. in the column-finding algorithm will benefit multiple parts of the code base.