### PR TITLE
Big Sur compatibility fixes

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -355,7 +355,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	if ([self.dataSource respondsToSelector:@selector(tableGrid:cellForColumn:row:)]) {
 		return [self.dataSource tableGrid:self cellForColumn:columnIndex row:rowIndex];
 	}
-	else {
+	else if (self.dataSource) {
 		NSLog(@"WARNING: MBTableGrid data source does not implement tableGrid:cellForColumn:row:");
 	}
 	return nil;
@@ -365,7 +365,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	if ([self.dataSource respondsToSelector:@selector(tableGrid:objectValueForColumn:row:)]) {
 		return [self.dataSource tableGrid:self objectValueForColumn:columnIndex row:rowIndex];
 	}
-	else {
+	else if (self.dataSource) {
 		NSLog(@"WARNING: MBTableGrid data source does not implement tableGrid:objectValueForColumn:row:");
 	}
 	return nil;
@@ -538,12 +538,9 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)paste:(id)sender {
-	
-    NSIndexSet *selectedColumns = [self selectedColumnIndexes];
-    NSIndexSet *selectedRows = [self selectedRowIndexes];
-    
     if ([self.delegate respondsToSelector:@selector(tableGrid:pasteCellsAtColumns:rows:)]) {
-        [self.delegate tableGrid:self pasteCellsAtColumns:selectedColumns rows:selectedRows];
+        [self.delegate tableGrid:self pasteCellsAtColumns:self.selectedColumnIndexes
+                            rows:self.selectedRowIndexes];
         [self reloadData];
     }
 }

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -2105,18 +2105,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 	// Take a snapshot of the view
 	NSImage *opaqueImage = [[NSImage alloc] initWithData:[self dataWithPDFInsideRect:columnsFrame]];
-
 	// Create the translucent drag image
-	NSImage *finalImage = [[NSImage alloc] initWithSize:opaqueImage.size];
-	[finalImage lockFocus];
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_8
-	[opaqueImage compositeToPoint:NSZeroPoint operation:NSCompositeCopy fraction:0.7];
-#else
-    [opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:0.7];
-#endif
-	[finalImage unlockFocus];
-
-	return finalImage;
+    return [NSImage imageWithSize:opaqueImage.size flipped:NO drawingHandler:^(NSRect dstRect) {
+        [opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:0.7];
+        return YES;
+    }];
 }
 
 - (NSImage *)_imageForSelectedRows {
@@ -2131,16 +2124,10 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	NSImage *opaqueImage = [[NSImage alloc] initWithData:[self dataWithPDFInsideRect:rowsFrame]];
 
 	// Create the translucent drag image
-	NSImage *finalImage = [[NSImage alloc] initWithSize:opaqueImage.size];
-	[finalImage lockFocus];
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_8
-	[opaqueImage compositeToPoint:NSZeroPoint operation:NSCompositeCopy fraction:0.7];
-#else
-    [opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:0.7];
-#endif
-	[finalImage unlockFocus];
-
-	return finalImage;
+    return [NSImage imageWithSize:opaqueImage.size flipped:NO drawingHandler:^(NSRect dstRect) {
+        [opaqueImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:0.7];
+        return YES;
+    }];
 }
 
 - (NSUInteger)_dropColumnForPoint:(NSPoint)aPoint {

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -822,42 +822,39 @@ NSString * const MBTableGridTrackingPartKey = @"part";
  */
 - (NSImage *)_cellSelectionCursorImage
 {
-	NSImage *image = [[NSImage alloc] initWithSize:NSMakeSize(20, 20)];
-	[image lockFocusFlipped:YES];
-	
-	NSRect horizontalInner = NSMakeRect(7.0, 2.0, 2.0, 12.0);
-	NSRect verticalInner = NSMakeRect(2.0, 7.0, 12.0, 2.0);
-	
-	NSRect horizontalOuter = NSInsetRect(horizontalInner, -1.0, -1.0);
-	NSRect verticalOuter = NSInsetRect(verticalInner, -1.0, -1.0);
-	
-	// Set the shadow
-	NSShadow *shadow = [[NSShadow alloc] init];
-	shadow.shadowColor = [NSColor colorWithCalibratedWhite:0.0 alpha:0.8];
-	shadow.shadowBlurRadius = 2.0;
-	shadow.shadowOffset = NSMakeSize(0, -1.0);
-	
-	[NSGraphicsContext.currentContext saveGraphicsState];
-	
-	[shadow set];
-	
-	[NSColor.blackColor set];
-	NSRectFill(horizontalOuter);
-	NSRectFill(verticalOuter);
-	
-	[NSGraphicsContext.currentContext restoreGraphicsState];
-	
-	// Fill them again to compensate for the shadows
-	NSRectFill(horizontalOuter);
-	NSRectFill(verticalOuter);
-	
-	[NSColor.whiteColor set];
-	NSRectFill(horizontalInner);
-	NSRectFill(verticalInner);
-	
-	[image unlockFocus];
-	
-	return image;
+    return [NSImage imageWithSize:NSMakeSize(20, 20) flipped:YES drawingHandler:^(NSRect dstRect) {
+        NSRect horizontalInner = NSMakeRect(7.0, 2.0, 2.0, 12.0);
+        NSRect verticalInner = NSMakeRect(2.0, 7.0, 12.0, 2.0);
+        
+        NSRect horizontalOuter = NSInsetRect(horizontalInner, -1.0, -1.0);
+        NSRect verticalOuter = NSInsetRect(verticalInner, -1.0, -1.0);
+        
+        // Set the shadow
+        NSShadow *shadow = [[NSShadow alloc] init];
+        shadow.shadowColor = [NSColor colorWithCalibratedWhite:0.0 alpha:0.8];
+        shadow.shadowBlurRadius = 2.0;
+        shadow.shadowOffset = NSMakeSize(0, -1.0);
+        
+        [NSGraphicsContext.currentContext saveGraphicsState];
+        
+        [shadow set];
+        
+        [NSColor.blackColor set];
+        NSRectFill(horizontalOuter);
+        NSRectFill(verticalOuter);
+        
+        [NSGraphicsContext.currentContext restoreGraphicsState];
+        
+        // Fill them again to compensate for the shadows
+        NSRectFill(horizontalOuter);
+        NSRectFill(verticalOuter);
+        
+        [NSColor.whiteColor set];
+        NSRectFill(horizontalInner);
+        NSRectFill(verticalInner);
+        
+        return YES;
+    }];
 }
 
 - (NSCursor *)_cellExtendSelectionCursor
@@ -873,66 +870,62 @@ NSString * const MBTableGridTrackingPartKey = @"part";
  */
 - (NSImage *)_cellExtendSelectionCursorImage
 {
-	NSImage *image = [[NSImage alloc] initWithSize:NSMakeSize(20, 20)];
-	[image lockFocusFlipped:YES];
-	
-	NSRect horizontalInner = NSMakeRect(7.0, 1.0, 0.5, 12.0);
-	NSRect verticalInner = NSMakeRect(1.0, 6.0, 12.0, 0.5);
-	
-	NSRect horizontalOuter = NSInsetRect(horizontalInner, -1.0, -1.0);
-	NSRect verticalOuter = NSInsetRect(verticalInner, -1.0, -1.0);
-	
-	[NSGraphicsContext.currentContext saveGraphicsState];
+    return [NSImage imageWithSize:NSMakeSize(20, 20) flipped:YES drawingHandler:^(NSRect dstRect) {
+        NSRect horizontalInner = NSMakeRect(7.0, 1.0, 0.5, 12.0);
+        NSRect verticalInner = NSMakeRect(1.0, 6.0, 12.0, 0.5);
+        
+        NSRect horizontalOuter = NSInsetRect(horizontalInner, -1.0, -1.0);
+        NSRect verticalOuter = NSInsetRect(verticalInner, -1.0, -1.0);
+        
+        [NSGraphicsContext.currentContext saveGraphicsState];
 
-	[NSColor.whiteColor set];
-	NSRectFill(horizontalOuter);
-	NSRectFill(verticalOuter);
-	
-	[NSGraphicsContext.currentContext restoreGraphicsState];
-	
-	// Fill them again to compensate for the shadows
-	NSRectFill(horizontalOuter);
-	NSRectFill(verticalOuter);
-	
-	[NSColor.blackColor set];
-	NSRectFill(horizontalInner);
-	NSRectFill(verticalInner);
-	
-	[image unlockFocus];
-	
-	return image;
+        [NSColor.whiteColor set];
+        NSRectFill(horizontalOuter);
+        NSRectFill(verticalOuter);
+        
+        [NSGraphicsContext.currentContext restoreGraphicsState];
+        
+        // Fill them again to compensate for the shadows
+        NSRectFill(horizontalOuter);
+        NSRectFill(verticalOuter);
+        
+        [NSColor.blackColor set];
+        NSRectFill(horizontalInner);
+        NSRectFill(verticalInner);
+        
+        return YES;
+    }];
 }
 
 - (NSImage *)_grabHandleImage;
 {
-	NSImage *image = [[NSImage alloc] initWithSize:NSMakeSize(kGRAB_HANDLE_SIDE_LENGTH, kGRAB_HANDLE_SIDE_LENGTH)];
-	[image lockFocusFlipped:YES];
-	
-	NSGraphicsContext *gc = NSGraphicsContext.currentContext;
-	
-	// Save the current graphics context
-	[gc saveGraphicsState];
-	
-	// Set the color in the current graphics context
-	
-	[NSColor.darkGrayColor setStroke];
-    [NSColor.systemYellowColor setFill];
-	
-	// Create our circle path
-	NSRect rect = NSMakeRect(1.0, 1.0, kGRAB_HANDLE_SIDE_LENGTH - 2.0, kGRAB_HANDLE_SIDE_LENGTH - 2.0);
-	NSBezierPath *circlePath = [NSBezierPath bezierPath];
-	circlePath.lineWidth = 0.5;
-	[circlePath appendBezierPathWithOvalInRect: rect];
-	
-	// Outline and fill the path
-	[circlePath fill];
-	[circlePath stroke];
-	
-	// Restore the context
-	[gc restoreGraphicsState];
-	[image unlockFocus];
-	
-	return image;
+    return [NSImage imageWithSize:NSMakeSize(kGRAB_HANDLE_SIDE_LENGTH, kGRAB_HANDLE_SIDE_LENGTH) flipped:YES
+                   drawingHandler:^(NSRect dstRect) {
+        NSGraphicsContext *gc = NSGraphicsContext.currentContext;
+        
+        // Save the current graphics context
+        [gc saveGraphicsState];
+        
+        // Set the color in the current graphics context
+        
+        [NSColor.darkGrayColor setStroke];
+        [NSColor.systemYellowColor setFill];
+        
+        // Create our circle path
+        NSRect rect = NSMakeRect(1.0, 1.0, kGRAB_HANDLE_SIDE_LENGTH - 2.0, kGRAB_HANDLE_SIDE_LENGTH - 2.0);
+        NSBezierPath *circlePath = [NSBezierPath bezierPath];
+        circlePath.lineWidth = 0.5;
+        [circlePath appendBezierPathWithOvalInRect: rect];
+        
+        // Outline and fill the path
+        [circlePath fill];
+        [circlePath stroke];
+        
+        // Restore the context
+        [gc restoreGraphicsState];
+        
+        return YES;
+    }];
 }
 
 @end

--- a/MBTableGridController.m
+++ b/MBTableGridController.m
@@ -76,7 +76,7 @@ NSString * const PasteboardTypeColumnClass = @"pasteboardTypeColumnClass";
 	[tableGrid reloadData];
 	
 	// Register to receive text strings
-	[tableGrid registerForDraggedTypes:@[NSStringPboardType]];
+	[tableGrid registerForDraggedTypes:@[NSPasteboardTypeString]];
 	
 	self.textCell = [[MBTableGridCell alloc] initTextCell:@""];
 	self.footerTextCell = [[MBTableGridFooterTextCell alloc] initTextCell:@""];
@@ -235,7 +235,7 @@ NSString * const PasteboardTypeColumnClass = @"pasteboardTypeColumnClass";
 {
 	NSPasteboard *pboard = [info draggingPasteboard];
 	
-	NSString *value = [pboard stringForType:NSStringPboardType];
+	NSString *value = [pboard stringForType:NSPasteboardTypeString];
 	[self tableGrid:aTableGrid setObjectValue:value forColumn:columnIndex row:rowIndex];
 	
 	return YES;


### PR DESCRIPTION
* Eliminate `lockFocus`, which is [buggy](https://developer.apple.com/documentation/macos-release-notes/appkit-release-notes-for-macos-11) on Big Sur
* Fix minor compile-time and run-time warnings

This also rips out a couple of ancient (Lion-era) code paths