### PR TITLE
Modernize grid and shadow colors

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -139,7 +139,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 + (BOOL)requiresConstraintBasedLayout { return YES; }
 
-- (id)initWithFrame:(NSRect)frameRect {
+- (instancetype)initWithFrame:(NSRect)frameRect {
 	if (self = [super initWithFrame:frameRect]) {
 		_columnWidths = [NSMutableDictionary dictionary];
 

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1301,7 +1301,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (BOOL)prepareForDragOperation:(id <NSDraggingInfo> )sender {
 	// Do not accept drag if this doesn't come from us
-	if([sender draggingSource] != self) {
+	if(sender.draggingSource != self) {
 		return NO;
 	}
 	return YES;

--- a/MBTableGridCell.m
+++ b/MBTableGridCell.m
@@ -35,14 +35,12 @@
 
 @implementation MBTableGridCell
 
--(id)initTextCell:(NSString *)aString
+-(instancetype)initTextCell:(NSString *)aString
 {
-    self = [super initTextCell:aString];
-    
-    if (self)
+    if (self = [super initTextCell:aString])
     {
         self.backgroundColor = NSColor.clearColor;
-		self.borderColor = NSColor.gridColor;
+        self.borderColor = NSColor.quaternaryLabelColor;
 		self.truncatesLastVisibleLine = YES;
         return self;
     }

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -105,7 +105,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 		isDraggingColumnOrRow = NO;
         shouldDrawFillPart = MBTableGridTrackingPartNone;
 
-		_rowHeight = 20.0f;
+		_rowHeight = 20.0;
 		
 		_defaultCell = [[MBTableGridCell alloc] initTextCell:@""];
         _defaultCell.bordered = YES;
@@ -238,7 +238,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
     
     // Fill the selection rectangle
     if (selectionPath) {
-        [[selectionColor colorWithAlphaComponent:0.2f] set];
+        [[selectionColor colorWithAlphaComponent:0.2] set];
         [selectionPath fill];
     }
     
@@ -831,7 +831,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
         
         // Set the shadow
         NSShadow *shadow = [[NSShadow alloc] init];
-        shadow.shadowColor = [NSColor colorWithCalibratedWhite:0.0 alpha:0.8];
+        shadow.shadowColor = NSColor.shadowColor;
         shadow.shadowBlurRadius = 2.0;
         shadow.shadowOffset = NSMakeSize(0, -1.0);
         

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -38,6 +38,11 @@
 NSString * const MBTableGridTrackingPartKey = @"part";
 
 @interface MBTableGrid (Private)
+@property (nonatomic, readonly) MBHorizontalEdge _stickyColumn;
+@property (nonatomic, readonly) MBVerticalEdge _stickyRow;
+@property (nonatomic, readonly) NSColor *_selectionColor;
+@property (nonatomic, readonly) BOOL _containsFirstResponder;
+
 - (NSCell *)_cellForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 - (id)_objectValueForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 - (void)_setObjectValue:(id)value forColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
@@ -45,10 +50,6 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 - (BOOL)_canEditCellAtColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 - (void)_setStickyColumn:(MBHorizontalEdge)stickyColumn row:(MBVerticalEdge)stickyRow;
 - (CGFloat)_widthForColumn:(NSUInteger)columnIndex;
-- (MBHorizontalEdge)_stickyColumn;
-- (MBVerticalEdge)_stickyRow;
-- (NSColor *)_selectionColor;
-- (BOOL)_containsFirstResponder;
 - (NSCell *)_footerCellForColumn:(NSUInteger)columnIndex;
 - (void)_didDoubleClickColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 - (NSRange)_rangeOfRowsIntersectingRect:(NSRect)rect;
@@ -56,11 +57,11 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 @end
 
 @interface MBTableGridContentView (Cursors)
-- (NSCursor *)_cellSelectionCursor;
-- (NSImage *)_cellSelectionCursorImage;
-- (NSCursor *)_cellExtendSelectionCursor;
-- (NSImage *)_cellExtendSelectionCursorImage;
-- (NSImage *)_grabHandleImage;
+@property (nonatomic, copy, readonly) NSCursor *_cellSelectionCursor;
+@property (nonatomic, copy, readonly) NSImage *_cellSelectionCursorImage;
+@property (nonatomic, copy, readonly) NSCursor *_cellExtendSelectionCursor;
+@property (nonatomic, copy, readonly) NSImage *_cellExtendSelectionCursorImage;
+@property (nonatomic, copy, readonly) NSImage *_grabHandleImage;
 @end
 
 @interface MBTableGridContentView (DragAndDrop)
@@ -98,8 +99,8 @@ NSString * const MBTableGridTrackingPartKey = @"part";
         grabHandleRect = NSZeroRect;
 		
 		// Cache the cursor image
-		cursorImage = [self _cellSelectionCursorImage];
-        cursorExtendSelectionImage = [self _cellExtendSelectionCursorImage];
+		cursorImage = self._cellSelectionCursorImage;
+        cursorExtendSelectionImage = self._cellExtendSelectionCursorImage;
 		
         isCompleting = NO;
 		isDraggingColumnOrRow = NO;
@@ -559,7 +560,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 
 - (void) resetCursorRects {
     NSRect visibleRect = NSIntersectionRect(self.enclosingScrollView.insetDocumentVisibleRect, self.visibleRect);
-    [self addCursorRect:visibleRect cursor:[self _cellSelectionCursor]];
+    [self addCursorRect:visibleRect cursor:self._cellSelectionCursor];
 }
 
 #pragma mark -

--- a/MBTableGridHeaderCell.m
+++ b/MBTableGridHeaderCell.m
@@ -49,8 +49,8 @@ extern CGFloat MBTableHeaderSortIndicatorMargin;
 
 - (NSColor*)borderColor
 {
-	if (_borderColor == nil)
-		_borderColor = NSColor.gridColor;
+    if (_borderColor == nil)
+        _borderColor = NSColor.quaternaryLabelColor;
 	return _borderColor;
 }
 

--- a/MBTableGridHeaderCell.m
+++ b/MBTableGridHeaderCell.m
@@ -130,7 +130,7 @@ extern CGFloat MBTableHeaderSortIndicatorMargin;
 }
 
 - (NSAttributedString *)attributedStringValue {
-    NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+    NSMutableParagraphStyle *paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
     if (self.orientation == MBTableHeaderVerticalOrientation) {
         paragraphStyle.alignment = NSTextAlignmentCenter;
     }

--- a/MBTableGridTextFinderClient.h
+++ b/MBTableGridTextFinderClient.h
@@ -15,6 +15,6 @@
     NSMutableDictionary<NSNumber *, NSDictionary<NSString *, id> *> *_pending_replacements;
 }
 
-- (id)initWithTableGrid:(MBTableGrid *)tableGrid;
+- (instancetype)initWithTableGrid:(MBTableGrid *)tableGrid;
 
 @end

--- a/MBTableGridTextFinderClient.m
+++ b/MBTableGridTextFinderClient.m
@@ -31,7 +31,7 @@
 #define _col(cellIndex, rows, cols) ((cellIndex) / (rows) + (cols-cols))
 #define _cell(rowIndex, columnIndex, rowCount, columCount) ((columnIndex) * (rowCount) + (rowIndex) + (columnCount-columnCount))
 
-- (id)initWithTableGrid:(MBTableGrid *)tableGrid {
+- (instancetype)initWithTableGrid:(MBTableGrid *)tableGrid {
     if (self = [super init]) {
         _tableGrid = tableGrid;
         _pending_replacements = [[NSMutableDictionary alloc] init];

--- a/MBTableGridVirtualString.h
+++ b/MBTableGridVirtualString.h
@@ -13,6 +13,6 @@
     MBTableGrid *_tableGrid;
 }
 
-- (id)initWithTableGrid:(MBTableGrid *)tableGrid;
+- (instancetype)initWithTableGrid:(MBTableGrid *)tableGrid;
 
 @end

--- a/MBTableGridVirtualString.m
+++ b/MBTableGridVirtualString.m
@@ -29,7 +29,7 @@
  * Searches in column-first order.
  */
 
-- (id)initWithTableGrid:(MBTableGrid *)tableGrid {
+- (instancetype)initWithTableGrid:(MBTableGrid *)tableGrid {
     if (self = [super init]) {
         _tableGrid = tableGrid;
     }


### PR DESCRIPTION
Use `NSColor.shadowColor` for shadows, and `NSColor.quaternaryLabelColor` for the grid lines. `NSColor.gridColor` has changed drastically in Big Sur, and is no longer usable in Dark Mode (it appears black).

Note that the [quaternaryLabelColor docs](https://developer.apple.com/documentation/appkit/nscolor/1534635-quaternarylabelcolor?language=objc) state that can be used "for separators between text items", so grid lines are a good candidate. The color seems to be identical to [`NSColor.separatorColor`](https://developer.apple.com/documentation/appkit/nscolor/2998831-separatorcolor?language=objc), which was introduced in Mojave.

This PR also changes a few init method signatures to return an `instancetype` rather than `id`.