### PR TITLE
Add tooltips for truncated header and content cells

### DIFF
--- a/MBTableGridContentView.h
+++ b/MBTableGridContentView.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSUInteger, MBTableGridTrackingPart)
  *				and editing capabilities of MBTableGrid. It is designed
  *				to be placed inside a scroll view.
  */
-@interface MBTableGridContentView : NSView <NSTextDelegate, NSTextViewDelegate, NSMenuDelegate> {
+@interface MBTableGridContentView : NSView <NSTextDelegate, NSTextViewDelegate, NSViewToolTipOwner> {
 	NSInteger mouseDownColumn;
 	NSInteger mouseDownRow;
 	

--- a/MBTableGridHeaderView.h
+++ b/MBTableGridHeaderView.h
@@ -32,7 +32,7 @@
  * @brief		\c MBTableGridHeaderView deals with the
  *				display and interaction with grid headers.
  */
-@interface MBTableGridHeaderView : NSView {
+@interface MBTableGridHeaderView : NSView<NSViewToolTipOwner> {
 	MBTableGridHeaderCell *headerCell;
 	MBTableGridHeaderOrientation orientation;
 	


### PR DESCRIPTION
Also:
* Remove an obsolete `<NSMenuDelegate>`
* Use round caps for the sort indicator.
* Call `[NSWindow invalidateCursorRectsForView:]` instead of `resetCursorRects`