### PR TITLE
New delegate methods to control the Find Bar

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -1146,6 +1146,29 @@ cells. A cell can individually override this behavior. */
 */
 - (void)tableGrid:(MBTableGrid *)aTableGrid didDoubleClickColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 
+#pragma mark -
+#pragma mark Find Bar Support
+
+/**
+ * @brief       Returns a boolean indicating whether the specified text finder action should be allowed.
+ *
+ * @param       aTableGrid      The table grid object that sent the message
+ * @param       finderActionTag The proposed finder action
+ *
+ * @see         NSTextFinderAction
+ */
+- (BOOL)tableGrid:(MBTableGrid *)aTableGrid validateTextFinderAction:(NSTextFinderAction)finderActionTag;
+
+/**
+ * @brief       Tells the delegate that the specified text finder action was performed.
+ *
+ * @param       aTableGrid      The table grid object that sent the message
+ * @param       finderActionTag The performed finder action
+ *
+ * @see         NSTextFinderAction
+ */
+- (void)tableGrid:(MBTableGrid *)aTableGrid didPerformTextFinderAction:(NSTextFinderAction)finderActionTag;
+
 /**
  * @}
  */

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1068,10 +1068,16 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (IBAction)performTextFinderAction:(NSControl *)sender {
     [_textFinder performAction:sender.tag];
+    if ([_delegate respondsToSelector:@selector(tableGrid:didPerformTextFinderAction:)]) {
+        [_delegate tableGrid:self didPerformTextFinderAction:sender.tag];
+    }
 }
 
 - (BOOL)validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)item {
     if (item.action == @selector(performTextFinderAction:)) {
+        if ([_delegate respondsToSelector:@selector(tableGrid:validateTextFinderAction:)]) {
+            return [_delegate tableGrid:self validateTextFinderAction:item.tag];
+        }
         return [_textFinder validateAction:item.tag];
     }
     return YES;
@@ -1079,11 +1085,11 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (BOOL)_shouldAbortFindOperation {
     if (NSThread.isMainThread)
-        return self.isHiddenOrHasHiddenAncestor || !contentScrollView.findBarVisible;
+        return self.isHiddenOrHasHiddenAncestor || !contentScrollView.isFindBarVisible;
     
     __block BOOL return_value = NO;
     NSOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
-        return_value = self.isHiddenOrHasHiddenAncestor || !self->contentScrollView.findBarVisible;
+        return_value = self.isHiddenOrHasHiddenAncestor || !self->contentScrollView.isFindBarVisible;
     }];
     [NSOperationQueue.mainQueue addOperations:@[ operation ] waitUntilFinished:YES];
     return return_value;

--- a/MBTableGridTextFinderClient.m
+++ b/MBTableGridTextFinderClient.m
@@ -98,7 +98,7 @@ typedef struct __attribute__((objc_boxable)) _NSRange NSRange;
     NSUInteger columnCount = _tableGrid.numberOfColumns;
     NSUInteger rowCount = _tableGrid.numberOfRows;
     
-    if (selectedRanges.count) {
+    if (selectedRanges.count && columnCount && rowCount) {
         NSUInteger cellIndex = selectedRanges.firstObject.rangeValue.location;
         NSUInteger rowIndex = _row(cellIndex, rowCount, columnCount);
         NSUInteger filteredIndex = _col(cellIndex, rowCount, columnCount);


### PR DESCRIPTION
* `tableGrid:validateTextFinderAction:` controls whether a particular action is allowed

* `tableGrid:didPerformTextFinderAction:` indicates that a particular action was performed

For a list of constants see https://developer.apple.com/documentation/appkit/nstextfinderaction