### PR TITLE
Improve selection/drawing performance in the sample project

### DIFF
--- a/MBTableGridController.m
+++ b/MBTableGridController.m
@@ -46,6 +46,12 @@ NSString * const PasteboardTypeColumnClass = @"pasteboardTypeColumnClass";
 
 @implementation MBTableGridController
 
++ (void)initialize {
+    // See https://gist.github.com/lukaskubanek/9a61ac71dc0db8bb04db2028f2635779
+    [NSUserDefaults.standardUserDefaults registerDefaults:@{ @"NSViewUsesAutomaticLayerBackingStores": @NO }];
+    [super initialize];
+}
+
 - (void)awakeFromNib 
 {
     


### PR DESCRIPTION
MBTableGrid makes heavy use of sub-rect invalidation, which on Big Sur doesn't work like it used to. This is a workaround which most applications will probably want to employ. (The change here affects the sample project – not the main framework.)

For a complete discussion of the underlying issue, see:

https://gist.github.com/lukaskubanek/9a61ac71dc0db8bb04db2028f2635779