### PR TITLE
Last-column resize fixes

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -40,6 +40,7 @@ NSString *MBTableGridDidMoveColumnsNotification         = @"MBTableGridDidMoveCo
 NSString *MBTableGridDidMoveRowsNotification            = @"MBTableGridDidMoveRowsNotification";
 CGFloat MBTableHeaderSortIndicatorWidth = 10.0;
 CGFloat MBTableHeaderSortIndicatorMargin = 4.0;
+CGFloat MBTableHeaderResizeLastColumnMargin = 4.0; // Need the header view to extend slightly past the rightmost column to catch clicks
 
 #define MBTableGridMinimumColumnWidth 60.0
 #define MBTableGridColumnHeaderHeight 24.0
@@ -447,6 +448,9 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
     }
 	
 	[self _setWidth:currentWidth forColumn:columnIndex];
+    
+    if (columnIndex == _numberOfColumns - 1)
+        [self scrollDistance:NSMakePoint(distance, 0.0)];
     
     // Update views with new sizes and mark the rightward columns as dirty
     for (NSView *horizontalView in @[ contentView, columnHeaderView, columnFooterView ]) {
@@ -1533,7 +1537,8 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
     contentScrollView.contentInsets = NSEdgeInsetsMake(columnHeaderScrollView.frame.size.height + _contentInsets.top,
                                                        rowHeaderScrollView.frame.size.width + _contentInsets.left,
                                                        columnFooterScrollView.frame.size.height + _contentInsets.bottom,
-                                                       rowFooterScrollView.frame.size.width + _contentInsets.right);
+                                                       rowFooterScrollView.frame.size.width + _contentInsets.right
+                                                       + MBTableHeaderResizeLastColumnMargin);
     rowHeaderScrollView.contentInsets = NSEdgeInsetsMake(columnHeaderScrollView.frame.size.height + _contentInsets.top, 0,
                                                          columnFooterScrollView.frame.size.height + _contentInsets.bottom, 0);
     rowFooterScrollView.contentInsets = NSEdgeInsetsMake(columnHeaderScrollView.frame.size.height + _contentInsets.top, 0,
@@ -1544,8 +1549,8 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 
 - (void)updateAuxiliaryViewSizesWithFrameSize:(NSSize)contentRectSize {
 	// Update the column header/footer view's size
-    NSSize columnHeaderSize = NSMakeSize(contentRectSize.width, NSHeight(columnHeaderView.frame));
-    NSSize columnFooterSize = NSMakeSize(contentRectSize.width, NSHeight(columnFooterView.frame));
+    NSSize columnHeaderSize = NSMakeSize(contentRectSize.width + MBTableHeaderResizeLastColumnMargin, NSHeight(columnHeaderView.frame));
+    NSSize columnFooterSize = NSMakeSize(contentRectSize.width + MBTableHeaderResizeLastColumnMargin, NSHeight(columnFooterView.frame));
     if (!contentScrollView.verticalScroller.isHidden && contentScrollView.scrollerStyle == NSScrollerStyleLegacy) {
         CGFloat scroller_width = [NSScroller scrollerWidthForControlSize:NSControlSizeRegular
                                                            scrollerStyle:contentScrollView.scrollerStyle];

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -295,22 +295,18 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
-    [self startAutoscrollTimer];
-    
+    if (!self.tableGrid.acceptsFirstResponder)
+        return;
+        
 	NSPoint mouseLocationInContentView = [self convertPoint:theEvent.locationInWindow fromView:nil];
 	mouseDownColumn = [self columnAtPoint:mouseLocationInContentView];
 	mouseDownRow = [self rowAtPoint:mouseLocationInContentView];
 
-	if(mouseDownRow == NSNotFound) {
+	if (mouseDownRow == NSNotFound || mouseDownColumn == NSNotFound) {
 		return;
 	}
     
-    // If the column wasn't found, probably need to flush the cached column rects
-    if (mouseDownColumn == NSNotFound) {
-        [self.tableGrid.columnRects removeAllObjects];
-        
-        mouseDownColumn = [self columnAtPoint:mouseLocationInContentView];
-    }
+    [self startAutoscrollTimer];
     
 	NSCell *cell = [self.tableGrid _cellForColumn:mouseDownColumn row: mouseDownRow];
 	BOOL cellEditsOnFirstClick = [cell respondsToSelector:@selector(editOnFirstClick)] ? ([(id<MBTableGridEditable>)cell editOnFirstClick]==YES) : self.tableGrid.singleClickCellEdit;


### PR DESCRIPTION
Add some margin so that the resize cursor area can extend slightly past the last column header. Update the content view's mouseDown handler since it's now slightly wider than the last column. Auto-scroll rightward as the last column is extended.