### PR TITLE
Fix cell border drawing

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -26,7 +26,8 @@
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
 
-@class MBTableGridHeaderView, MBTableGridFooterView, MBTableGridHeaderCell, MBTableGridContentView;
+@class MBTableGridHeaderView, MBTableGridFooterView, MBTableGridContentView;
+@class MBTableGridCell, MBTableGridHeaderCell;
 @protocol MBTableGridDelegate, MBTableGridDataSource;
 
 /* Notifications */
@@ -687,7 +688,7 @@ cells. A cell can individually override this behavior. */
  *
  * @return		The cell to render the specified column.
  */
-- (NSCell*) tableGrid:(MBTableGrid *)aTableGrid cellForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
+- (__kindof MBTableGridCell *)tableGrid:(MBTableGrid *)aTableGrid cellForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 
 @optional
 

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -352,7 +352,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 	return YES;
 }
 
-- (NSCell*) _cellForColumn: (NSUInteger)columnIndex row:(NSUInteger)rowIndex {
+- (__kindof MBTableGridCell *) _cellForColumn: (NSUInteger)columnIndex row:(NSUInteger)rowIndex {
 	if ([self.dataSource respondsToSelector:@selector(tableGrid:cellForColumn:row:)]) {
 		return [self.dataSource tableGrid:self cellForColumn:columnIndex row:rowIndex];
 	}
@@ -1713,7 +1713,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
         dirtyRect = NSUnionRect([self.contentView rectOfColumn:columnIndexes.firstIndex],
                                 [self.contentView rectOfColumn:columnIndexes.lastIndex]);
     }
-    return dirtyRect;
+    return NSInsetRect(dirtyRect, -1.0, -1.0);
 }
 
 - (NSRect)frameOfCellAtColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex {

--- a/MBTableGridCell.h
+++ b/MBTableGridCell.h
@@ -32,4 +32,6 @@
  */
 @interface MBTableGridCell : NSTextFieldCell
 
+- (void)drawBorderWithFrame:(NSRect)cellFrame inView:(NSView *)controlView;
+
 @end

--- a/MBTableGridCell.m
+++ b/MBTableGridCell.m
@@ -48,18 +48,21 @@
     return nil;
 }
 
+- (void)drawBorderWithFrame:(NSRect)cellFrame inView:(NSView *)controlView {
+    [_borderColor set];
+    
+    // Draw the right border
+    NSRect rightLine = NSMakeRect(NSMaxX(cellFrame)-1.0, NSMinY(cellFrame), 1.0, NSHeight(cellFrame));
+    NSRectFill(rightLine);
+    
+    // Draw the bottom border
+    NSRect bottomLine = NSMakeRect(NSMinX(cellFrame), NSMaxY(cellFrame)-1.0, NSWidth(cellFrame), 1.0);
+    NSRectFill(bottomLine);
+}
+
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
-	[_borderColor set];
-	
-	// Draw the right border
-	NSRect rightLine = NSMakeRect(NSMaxX(cellFrame)-1.0, NSMinY(cellFrame), 1.0, NSHeight(cellFrame));
-	NSRectFill(rightLine);
-	
-	// Draw the bottom border
-	NSRect bottomLine = NSMakeRect(NSMinX(cellFrame), NSMaxY(cellFrame)-1.0, NSWidth(cellFrame), 1.0);
-	NSRectFill(bottomLine);
-
+    [self drawBorderWithFrame:cellFrame inView:controlView];
 	[self drawInteriorWithFrame:cellFrame inView:controlView];
 }
 


### PR DESCRIPTION
Currently the cell borders are drawn on top of the selection color, which looks bad. This refactors things a bit so that the drawing layers instead of (cross-sectional view of the layers of "paint"):

```
==    Text   ==
==   Border  ==
== Selection ==
```

We have:

```
==    Text   ==
== Selection ==
==   Border  ==
```

Before:

<img width="502" alt="image" src="https://user-images.githubusercontent.com/134711/208415722-fe0da368-983a-41b5-8b6c-a1a74c90c9d0.png">

After:

<img width="502" alt="image" src="https://user-images.githubusercontent.com/134711/208415480-cddb80f5-f131-4e27-a0e0-70c48c50bbe1.png">
