### PR TITLE
Fixes for editing text in the selected cell

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1099,13 +1099,7 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 }
 
 - (void)insertText:(id)aString {
-	NSUInteger column = self.selectedColumnIndexes.firstIndex;
-	NSUInteger row = self.selectedRowIndexes.firstIndex;
-	NSCell *selectedCell = [self _cellForColumn:column row:row];
-
-	[contentView editSelectedCell:self text:aString];
-	
-	if ([selectedCell isKindOfClass:[MBTableGridCell class]]) {
+	if ([contentView editSelectedCell:self text:aString]) {
 		// Insert the typed string into the field editor
 		NSText *fieldEditor = [self.window fieldEditor:YES forObject:contentView];
 		fieldEditor.delegate = contentView;

--- a/MBTableGridContentView.h
+++ b/MBTableGridContentView.h
@@ -104,7 +104,7 @@ typedef NS_ENUM(NSUInteger, MBTableGridTrackingPart)
  *				selects the top-left one and begins
  *				editing its value.
  */
-- (void)editSelectedCell:(id)sender text:(NSString *)aString;
+- (__kindof MBTableGridCell *)editSelectedCell:(id)sender text:(NSString *)aString;
 
 /**
  * @}

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -727,18 +727,26 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 }
 */
 
-- (void)editSelectedCell:(id)sender text:(NSString *)aString
+- (__kindof MBTableGridCell *)editSelectedCell:(id)sender text:(NSString *)aString
 {
 	NSInteger selectedColumn = self.tableGrid.selectedColumnIndexes.firstIndex;
 	NSInteger selectedRow = self.tableGrid.selectedRowIndexes.firstIndex;
-	NSCell *selectedCell = [self.tableGrid _cellForColumn:selectedColumn row: selectedRow];
+    if (selectedColumn == NSNotFound || selectedRow == NSNotFound) {
+        editedColumn = NSNotFound;
+        editedRow = NSNotFound;
+        return nil;
+    }
+
+    MBTableGridCell *selectedCell = [self.tableGrid _cellForColumn:selectedColumn row: selectedRow];
 
 	// Check if the cell can be edited
 	if(![self.tableGrid _canEditCellAtColumn:selectedColumn row:selectedColumn]) {
 		editedColumn = NSNotFound;
 		editedRow = NSNotFound;
-		return;
+        return nil;
 	}
+
+    [self stopAutoscrollTimer];
 
 	// Select it and only it
 	if (self.tableGrid.selectedColumnIndexes.count > 1 && editedColumn != NSNotFound) {
@@ -752,7 +760,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	editedColumn = selectedColumn;
 	editedRow = selectedRow;
 
-	NSRect cellFrame = [self frameOfCellAtColumn:editedColumn row:editedRow];
+    NSRect cellFrame = [selectedCell titleRectForBounds:[self frameOfCellAtColumn:editedColumn row:editedRow]];
 
 	selectedCell.editable = YES;
 	selectedCell.selectable = YES;
@@ -774,6 +782,7 @@ NSString * const MBTableGridTrackingPartKey = @"part";
 	else {
         [selectedCell selectWithFrame:cellFrame inView:self editor:editor delegate:self start:0 length:currentValue.length];
 	}
+    return selectedCell;
 }
 
 #pragma mark Layout Support


### PR DESCRIPTION
* Place the edited text correctly inside the cell using `titleRectForBounds:`
* Short-circuit if there's no selection
* Stop autoscroll when editing
* Return the edited cell from `editSelectedCell:text:`