### PR TITLE
Fix: performDragOperation with invalid column leads to crash

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1443,6 +1443,10 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 			// Get the index to move the rows to
 			NSUInteger dropRow = [self _dropRowForPoint:mouseLocation];
 
+			if (dropRow == NSNotFound) {
+				return NO;
+			}
+            
 			// Tell the data source to move the rows
 			BOOL didDrag = [self.dataSource tableGrid:self moveRows:draggedRows toIndex:dropRow];
 

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -1399,6 +1399,10 @@ NS_INLINE MBVerticalEdge MBOppositeVerticalEdge(MBVerticalEdge other) {
 			// Get the index to move the columns to
 			NSUInteger dropColumn = [self _dropColumnForPoint:mouseLocation];
 
+			if (dropColumn == NSNotFound) {
+				return NO;
+			}
+            
 			// Tell the data source to move the columns
 			BOOL didDrag = [self.dataSource tableGrid:self moveColumns:draggedColumns toIndex:dropColumn];
 


### PR DESCRIPTION
Received crash report from macOS 14.7. It's a bit bizarre as draggingUpdated should reject this drag&drop. I suspect it's related to scrolling/scrollbar changes under the hood on 14.7/15.0.