### PR TITLE
Resizing column header does not call mouseExited

### DIFF
--- a/MBTableGridHeaderView.m
+++ b/MBTableGridHeaderView.m
@@ -376,6 +376,7 @@ NSString* kAutosavedColumnHiddenKey = @"AutosavedColumnHidden";
 		}
 		
         isResizing = NO;
+	canResize = NO;
 		
         [self.window enableCursorRects];
         [self.window invalidateCursorRectsForView:self];


### PR DESCRIPTION
Column header resizing disablesCursorUpdates and mouseExited will not be called after mouseDragging. This will block column selection for further mouseDown events until mouseExited is generated.  Since tracking areas are updated in mouseUp event we can reset canResize variable in mouseUp. PS: Updated tracking areas will generate mouseEntered event automatically.