### PR TITLE
Fixing circular memory issue

### DIFF
--- a/MBTableGridTextFinderClient.h
+++ b/MBTableGridTextFinderClient.h
@@ -10,7 +10,7 @@
 @class MBTableGrid;
 
 @interface MBTableGridTextFinderClient : NSObject<NSTextFinderClient> {
-    MBTableGrid *_tableGrid;
+    __weak MBTableGrid *_tableGrid;
     
     NSMutableDictionary<NSNumber *, NSDictionary<NSString *, id> *> *_pending_replacements;
 }


### PR DESCRIPTION
MBTableGridTextFinderClient strongly holds tableGrid making a circular reference that prevents dealloc.

@interface MBTableGridTextFinderClient : NSObject<NSTextFinderClient> {
    MBTableGrid *_tableGrid;

https://github.com/pixelspark/mbtablegrid/blob/e3890fc2d86a85935f5a04d3a221403d291ca19a/MBTableGridTextFinderClient.h#L13

_textFinderClient = [[MBTableGridTextFinderClient alloc] initWithTableGrid:self];

https://github.com/pixelspark/mbtablegrid/blob/e3890fc2d86a85935f5a04d3a221403d291ca19a/MBTableGrid.m#L294

This fixes #88 